### PR TITLE
Feat: Add visibility template for single indicators

### DIFF
--- a/src/css/card.css
+++ b/src/css/card.css
@@ -102,6 +102,10 @@ header h1 {
   flex-wrap: wrap;
 }
 
+.item.hidden {
+  display: none !important;
+}
+
 .info-box.range {
   flex-wrap: nowrap !important;
   justify-content: center;

--- a/src/editor/components/panel-indicator.ts
+++ b/src/editor/components/panel-indicator.ts
@@ -11,6 +11,7 @@ import {
 } from '../../types';
 import editorcss from '../../css/editor.css';
 import { fireEvent } from 'custom-card-helpers';
+import { CONFIG_VALUES } from '../editor-const';
 
 import Sortable from 'sortablejs';
 
@@ -137,6 +138,15 @@ export class PanelIndicator extends LitElement {
 
     const singleTemplate = [
       {
+        value: indicator.visibility,
+        pickerType: 'template',
+        configValue: 'visibility',
+        options: {
+          label: 'Visibility template',
+          helperText: 'Template for the visibility. Use Jinja2 template with result as true to show the indicator',
+        },
+      },
+      {
         value: indicator.icon_template,
         pickerType: 'template',
         configValue: 'icon_template',
@@ -161,9 +171,12 @@ export class PanelIndicator extends LitElement {
         <div class="sub-content">
           ${singlePicker.map((config) => this._createItemPicker({ ...config, ...sharedConfig }))}
         </div>
+      </div>
+      <div class="sub-panel-config">
         ${singleTemplate.map((config) => this._createItemPicker({ ...config, ...sharedConfig }, 'template-content'))}
       </div>
     `;
+
     return subPanelConfig;
   }
 
@@ -557,7 +570,7 @@ export class PanelIndicator extends LitElement {
     let configIndex = target.configIndex;
     let newValue: any;
 
-    if (configValue === 'attribute') {
+    if (CONFIG_VALUES.includes(configValue)) {
       newValue = ev.detail.value;
     } else {
       newValue = target.value;

--- a/src/editor/editor-const.ts
+++ b/src/editor/editor-const.ts
@@ -77,6 +77,9 @@ const DETAIL_CONFIG_VALUES = [
   'value_size',
   'top',
   'left',
+  'visibility',
+  'state_template',
+  'icon_template',
 ];
 
 const PREVIEW_CONFIG_TYPES = ['btn_preview', 'default_card_preview', 'card_preview', 'tire_preview'];

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,15 +35,17 @@ export type HomeAssistantExtended = {
 export interface IndicatorConfig {
   attribute?: string;
   entity: string;
-  icon?: string;
+  icon: string;
   icon_template?: string;
   state_template?: string;
+  visibility?: string;
 }
 
 export type IndicatorEntity = Array<{
   entity: string;
   icon: string;
   state: string;
+  visibility?: boolean;
 }>;
 
 // IndicatorGroup configuration for a group of indicators

--- a/src/utils/create.ts
+++ b/src/utils/create.ts
@@ -25,7 +25,8 @@ interface PickerOptions {
     | 'selectorBoolean'
     | 'template'
     | 'textfield'
-    | 'theme';
+    | 'theme'
+    | 'new_template';
   value: boolean | number | string;
 }
 
@@ -152,7 +153,7 @@ export const Picker = ({
         .required=${false}
       ></ha-selector>
     `,
-    template: html`
+    new_template: html`
       <div class="template-ui">
         <p>${options?.label}</p>
         <ha-code-editor
@@ -173,6 +174,23 @@ export const Picker = ({
         <ha-input-helper-text>${options?.helperText}</ha-input-helper-text>
       </div>
     `,
+    template: html`
+      <ha-selector
+        .hass=${hass}
+        .value=${value}
+        .configValue=${configValue}
+        .configType=${configType}
+        .configIndex=${configIndex}
+        .label=${options?.label || 'template'}
+        .helper=${options?.helperText}
+        .selector=${{ template: {} }}
+        .index=${configIndex}
+        @value-changed=${handleValueChange}
+        .required=${false}
+      >
+      </ha-selector>
+    `,
+
     textfield: html`
       <ha-textfield
         class="form-text"

--- a/src/utils/ha-helper.ts
+++ b/src/utils/ha-helper.ts
@@ -91,7 +91,9 @@ export async function getSingleIndicators(
         ? hass.formatEntityAttributeValue(stateObj, indicator.attribute)
         : hass.formatEntityState(stateObj);
 
-    singleIndicator.push({ entity, icon: iconValue, state });
+    const visibility = indicator.visibility ? await getBooleanTemplate(hass, indicator.visibility) : true;
+
+    singleIndicator.push({ entity, icon: iconValue, state, visibility });
   }
   return singleIndicator;
 }

--- a/src/vehicle-status-card.ts
+++ b/src/vehicle-status-card.ts
@@ -341,8 +341,8 @@ export class VehicleStatusCard extends LitElement {
     if (!this._config.indicators) return html``;
     // Render single indicators
     const singleIndicators = Object.values(this._indicatorsSingle).map(
-      ({ entity, icon, state }) => html`
-        <div class="item">
+      ({ entity, icon, state, visibility }) => html`
+        <div class="item ${visibility === false ? 'hidden' : ''}">
           <ha-state-icon
             .hass=${this._hass}
             .stateObj=${entity ? this._hass.states[entity] : undefined}


### PR DESCRIPTION
This pull request adds a new feature to the single indicators in the vehicle status card. It introduces a visibility template option, which allows users to define a Jinja2 template to determine whether the indicator should be shown or hidden based on the result. This provides more flexibility in customizing the visibility of single indicators.