### PR TITLE
Feat: Add color template option for indicators

### DIFF
--- a/src/components/vsc-indicators.ts
+++ b/src/components/vsc-indicators.ts
@@ -81,7 +81,7 @@ export class VscIndicators extends LitElement {
         ${items.map(({ entity, icon, name, state }) => {
           return html`
             <div class="item charge">
-              <div>
+              <div class="icon-state">
                 <ha-state-icon .hass=${this.hass} .stateObj=${this.hass.states[entity]} .icon=${icon}></ha-state-icon>
                 <span>${state}</span>
               </div>
@@ -97,12 +97,13 @@ export class VscIndicators extends LitElement {
 
   private _renderSingleIndicators(): TemplateResult {
     const indicator = Object.values(this._indicatorsSingle).map(
-      ({ entity, icon, state, visibility }) => html`
+      ({ entity, icon, state, visibility, color }) => html`
         <div class="item ${visibility === false ? 'hidden' : ''}">
           <ha-state-icon
             .hass=${this.hass}
             .stateObj=${entity ? this.hass.states[entity] : undefined}
             .icon=${icon}
+            style=${color ? `color: ${color}` : ''}
           ></ha-state-icon>
           <div><span>${state}</span></div>
         </div>
@@ -114,9 +115,15 @@ export class VscIndicators extends LitElement {
 
   private _renderGroupIndicators(): TemplateResult {
     // Helper function to render group
-    const groupIndicator = (icon: string, label: string, onClick: (index: number) => void, isActive: boolean) => html`
+    const groupIndicator = (
+      icon: string,
+      label: string,
+      color: string,
+      onClick: (index: number) => void,
+      isActive: boolean
+    ) => html`
       <div class="item active-btn" @click=${onClick}>
-        <ha-icon icon=${icon}></ha-icon>
+        <ha-icon icon=${icon} style=${color ? `color: ${color}` : ''}></ha-icon>
         <div class="added-item-arrow">
           <span>${label}</span>
           <div class="subcard-icon ${isActive ? 'active' : ''}" style="margin-bottom: 2px">
@@ -130,7 +137,7 @@ export class VscIndicators extends LitElement {
     // Render group indicators
     const groupIndicators = groupWithItems.map((group, index) => {
       const isActive = this._activeGroupIndicator === index;
-      return groupIndicator(group.icon, group.name, () => this._toggleGroupIndicator(index), isActive);
+      return groupIndicator(group.icon, group.name, group.color, () => this._toggleGroupIndicator(index), isActive);
     });
 
     return html`${groupIndicators}`;

--- a/src/css/card.css
+++ b/src/css/card.css
@@ -91,15 +91,21 @@ header h1 {
 }
 
 .info-box {
-  --mdc-icon-size: 17px;
+  --mdc-icon-size: 20px;
   display: flex;
   justify-content: center;
-  align-items: center;
   position: relative;
   width: 100%;
   height: fit-content;
   gap: var(--vic-gutter-gap);
   flex-wrap: wrap;
+}
+
+@media screen and (max-width: 768px) {
+  .info-box {
+    --mdc-icon-size: 17px;
+  }
+
 }
 
 .item.hidden {
@@ -110,6 +116,7 @@ header h1 {
   flex-wrap: nowrap !important;
   justify-content: center;
   text-wrap: nowrap;
+  align-items: center;
 }
 
 .info-box.range .item {
@@ -120,7 +127,6 @@ header h1 {
 
 .info-box .item {
   display: flex;
-  align-items: center;
   gap: 0.4rem;
 }
 
@@ -171,6 +177,12 @@ header h1 {
   flex-direction: column;
   gap: initial;
   width: max-content;
+}
+
+.info-box.charge .icon-state {
+  display: flex;
+  height: auto;
+  align-items: center;
 }
 
 .info-box.charge .item-name {

--- a/src/editor/components/panel-indicator.ts
+++ b/src/editor/components/panel-indicator.ts
@@ -164,6 +164,15 @@ export class PanelIndicator extends LitElement {
           helperText: 'Template for the state',
         },
       },
+      {
+        value: indicator.color,
+        pickerType: 'template',
+        configValue: 'color',
+        options: {
+          label: 'Color template',
+          helperText: 'Template for the color of the indicator',
+        },
+      },
     ];
 
     const subPanelConfig = html`
@@ -203,6 +212,8 @@ export class PanelIndicator extends LitElement {
     const groupPicker = [
       { value: group.name, pickerType: 'textfield', label: 'Group name', configValue: 'name' },
       { value: group.icon, pickerType: 'icon' },
+    ];
+    const groupTemplate = [
       {
         value: group.visibility,
         pickerType: 'template',
@@ -212,11 +223,23 @@ export class PanelIndicator extends LitElement {
           helperText: 'Template for the visibility. Use Jinja2 template with result as true to show the indicator',
         },
       },
+      {
+        value: group.color,
+        pickerType: 'template',
+        configValue: 'color',
+        options: {
+          label: 'Color template',
+          helperText: 'Template for the color of the indicator',
+        },
+      },
     ];
 
     const groupNameIcon = html`
       <div class="sub-content">
         ${groupPicker.map((config) => this._createItemPicker({ ...config, ...configShared }))}
+      </div>
+      <div class="sub-panel-config">
+        ${groupTemplate.map((config) => this._createItemPicker({ ...config, ...configShared }, 'template-content'))}
       </div>
     `;
 

--- a/src/editor/editor-const.ts
+++ b/src/editor/editor-const.ts
@@ -87,6 +87,7 @@ const DETAIL_CONFIG_VALUES = [
   'delay',
   'speed',
   'effect',
+  'color',
 ];
 
 const PREVIEW_CONFIG_TYPES = ['btn_preview', 'default_card_preview', 'card_preview', 'tire_preview'];

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,7 @@ export interface IndicatorConfig {
   icon_template?: string;
   state_template?: string;
   visibility?: string;
+  color?: string;
 }
 
 export type IndicatorEntity = Array<{
@@ -46,6 +47,7 @@ export type IndicatorEntity = Array<{
   icon: string;
   state: string;
   visibility?: boolean;
+  color?: string;
 }>;
 
 // IndicatorGroup configuration for a group of indicators
@@ -54,6 +56,7 @@ export interface IndicatorGroupConfig {
   items: Array<IndicatorGroupItemConfig>; // Array of group items
   name: string;
   visibility: string;
+  color?: string;
 }
 
 // Configuration for individual items in the indicatorGroup
@@ -76,6 +79,7 @@ export type IndicatorGroupEntity = Array<{
   }>; // Array of individual indicator items
   name: string;
   visibility?: boolean;
+  color: string;
 }>;
 
 /* ----------------------- RANGE INFO CONFIG INTERFACE ---------------------- */

--- a/src/utils/ha-helper.ts
+++ b/src/utils/ha-helper.ts
@@ -82,7 +82,9 @@ export async function getSingleIndicators(
 
     const visibility = indicator.visibility ? await getTemplateBoolean(hass, indicator.visibility) : true;
 
-    singleIndicator.push({ entity, icon: iconValue, state, visibility });
+    const color = indicator.color ? await getTemplateValue(hass, indicator.color) : '';
+
+    singleIndicator.push({ entity, icon: iconValue, state, visibility, color });
   }
   return singleIndicator;
 }
@@ -99,6 +101,7 @@ export async function getGroupIndicators(
       items: [],
       name: group.name,
       visibility: await getTemplateBoolean(hass, group.visibility),
+      color: group.color ? await getTemplateValue(hass, group.color) : '',
     });
 
     if (group.items) {

--- a/src/vehicle-status-card.ts
+++ b/src/vehicle-status-card.ts
@@ -13,7 +13,7 @@ import { styleMap } from 'lit-html/directives/style-map.js';
 import { customElement, property, query, state } from 'lit/decorators';
 
 import './components';
-import { VehicleButtonsGrid, ImagesSlide, VscRangeInfo } from './components';
+import { VehicleButtonsGrid, ImagesSlide, VscRangeInfo, VscIndicators } from './components';
 import { DEFAULT_CONFIG } from './const/const';
 import { TIRE_BG } from './const/img-const';
 import cardcss from './css/card.css';
@@ -51,6 +51,7 @@ export class VehicleStatusCard extends LitElement {
   @query('vehicle-buttons-grid') _vehicleButtonsGrid!: VehicleButtonsGrid;
   @query('images-slide') _imagesSlide!: ImagesSlide;
   @query('vsc-range-info') _rangeInfo!: VscRangeInfo;
+  @query('vsc-indicators') _indicators!: VscIndicators;
 
   constructor() {
     super();


### PR DESCRIPTION
This pull request adds a new feature to the code that allows users to specify a color template for indicators. Previously, only the entity, icon, state, and visibility could be configured for indicators. With this change, users can now also define a color template for each indicator. This provides more flexibility in customizing the appearance of indicators.