### PR TITLE
Add history period configuration for map popup

### DIFF
--- a/src/components/shared/vsc-maptiler-popup.ts
+++ b/src/components/shared/vsc-maptiler-popup.ts
@@ -28,9 +28,9 @@ enum THEME_MODE {
 
 type THEME = 'dark' | 'light';
 const BOUNDS_OPTS = {
-  padding: 50,
+  padding: 25,
   animate: true,
-  maxZoom: 15,
+  maxZoom: 14,
   pitch: 0,
   bearing: 0,
 };
@@ -60,6 +60,10 @@ export class VscMaptilerPopup extends LitElement {
 
   private get mapConfig(): MiniMapConfig {
     return this.card._config.mini_map!;
+  }
+
+  private get pathHidden(): boolean {
+    return localStorage.getItem(MAP_STORAGE.PATH_HIDDEN) === 'true';
   }
 
   connectedCallback(): void {
@@ -162,7 +166,7 @@ export class VscMaptilerPopup extends LitElement {
         this.map!.setLanguage(language);
       }
 
-      if (!this._bounds!.isEmpty() && mapConfig.auto_fit) {
+      if (!this._bounds!.isEmpty() && mapConfig.auto_fit && !this.pathHidden) {
         this.map!.fitBounds(this._bounds!, { ...BOUNDS_OPTS, maxZoom: defaultZoom });
       }
     });
@@ -191,9 +195,15 @@ export class VscMaptilerPopup extends LitElement {
         const findCarBtn = event.currentTarget as HTMLElement;
         const haIcon = findCarBtn.querySelector('ha-icon') as HTMLElement;
         if (!this._markerFocus) {
-          this.map!.fitBounds(this._bounds!, { ...BOUNDS_OPTS, maxZoom: defaultZoom });
+          // Fit the map to the bounds if marker is not focused
+          if (this.pathHidden) {
+            this.map!.flyTo({ center: [lon, lat], zoom: defaultZoom, bearing: 0, pitch: 0 });
+          } else {
+            this.map!.fitBounds(this._bounds!, { ...BOUNDS_OPTS, maxZoom: defaultZoom });
+          }
           haIcon.setAttribute('icon', 'mdi:target');
         } else {
+          // Fly to the marker if focused
           this.map!.flyTo({ center: [lon, lat], ...MARKER_FLYTO_OPTS });
           haIcon.setAttribute('icon', 'mdi:image-filter-center-focus');
         }

--- a/src/editor/editor.ts
+++ b/src/editor/editor.ts
@@ -604,6 +604,16 @@ export class VehicleStatusCardEditor extends LitElement implements LovelaceCardE
         value: miniMap.path_color,
         options: { selector: { ui_color: { include_none: false, include_state: false } } },
       },
+      {
+        configValue: 'history_period',
+        label: 'History Period',
+        pickerType: 'attribute',
+        value: miniMap.history_period || undefined,
+        items: [
+          { label: 'Today', value: 'today' },
+          { label: 'Yesterday', value: 'yesterday' },
+        ],
+      },
     ];
 
     const createPickers = (configs: any[]) =>
@@ -766,6 +776,7 @@ export class VehicleStatusCardEditor extends LitElement implements LovelaceCardE
       'path_color',
       'map_zoom',
       'auto_fit',
+      'history_period',
     ];
     // Ensure we handle the boolean value correctly
     let newValue: any = target.checked !== undefined ? target.checked : target.value;

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -73,6 +73,7 @@ export interface MapData {
   address: Partial<Address>;
 }
 
+type HISTORY_PERIOD = 'today' | 'yesterday' | undefined;
 export interface MiniMapConfig {
   default_zoom: number;
   device_tracker: string;
@@ -86,6 +87,7 @@ export interface MiniMapConfig {
   path_color?: string;
   auto_fit?: boolean;
   map_zoom?: number;
+  history_period?: HISTORY_PERIOD;
 }
 
 type THEME_MODE = 'auto' | 'dark' | 'light';

--- a/src/vehicle-status-card.ts
+++ b/src/vehicle-status-card.ts
@@ -281,7 +281,9 @@ export class VehicleStatusCard extends LitElement implements LovelaceCard {
 
   private _renderMiniMap(): TemplateResult {
     if (this._isSectionHidden(SECTION.MINI_MAP)) return html``;
-    if (!this._config?.mini_map?.device_tracker) return this._showWarning('Device tracker not available');
+    const deviceTracker = this._config?.mini_map?.device_tracker;
+    const deviceState = this._hass.states[deviceTracker].state;
+    if (!deviceTracker || /(unknown)/.test(deviceState)) return this._showWarning('Device tracker not available');
     const mapData = _getMapData(this);
     return html`
       <div id=${SECTION.MINI_MAP} style=${`min-width: ${this._cardWidth}px`}>


### PR DESCRIPTION
Improve validation for device trackers, adjust map bounds options, and introduce a history period configuration for better data handling in the mini-map.