### PR TITLE
Add notification badge customization options for buttons

### DIFF
--- a/src/components/shared/vsc-button-single.ts
+++ b/src/components/shared/vsc-button-single.ts
@@ -13,7 +13,7 @@ import { RenderTemplateResult, subscribeRenderTemplate } from '../../types';
 import { addActions, hasTemplate, strStartsWith } from '../../utils';
 import { VehicleButtonsGrid } from '../vsc-vehicle-buttons-grid';
 
-const TEMPLATE_KEYS = ['state_template', 'notify', 'color', 'picture_template'] as const;
+const TEMPLATE_KEYS = ['state_template', 'notify', 'color', 'picture_template', 'notify_color', 'notify_icon'] as const;
 type TemplateKey = (typeof TEMPLATE_KEYS)[number];
 
 const COLOR_AlPHA = '.2';
@@ -101,6 +101,14 @@ export class VehicleButtonSingle extends LitElement {
       case 'picture_template':
         const picture = button.picture_template ? this.getValue('picture_template') || button.picture_template : '';
         return picture;
+      case 'notify_color':
+        const notifyColor = button.notify_color
+          ? this.getValue('notify_color') || button.notify_color
+          : 'var(--error-color)';
+        return notifyColor;
+      case 'notify_icon':
+        const notifyIcon = button.notify_icon ? this.getValue('notify_icon') || button.notify_icon : 'mdi:alert-circle';
+        return notifyIcon;
     }
   }
   private async _tryConnect(): Promise<void> {
@@ -203,6 +211,8 @@ export class VehicleButtonSingle extends LitElement {
     const state = this._getTemplateValue('state_template');
     const color = this._getTemplateValue('color');
     const notify = this._getTemplateValue('notify');
+    const notifyColor = this._getTemplateValue('notify_color');
+    const notifyIcon = this._getTemplateValue('notify_icon');
     const iconBackground = color ? color : 'var(--primary-text-color)';
     const picture = String(this._getTemplateValue('picture_template'));
     const isPictureUrl = strStartsWith(picture, 'http') || strStartsWith(picture, '/');
@@ -230,8 +240,8 @@ export class VehicleButtonSingle extends LitElement {
                     style=${color ? `color: ${color}` : ''}
                   ></ha-state-icon>`}
             </div>
-            <div class="item-notify" ?hidden=${!notify || hideNotify}>
-              <ha-icon icon="mdi:alert-circle"></ha-icon>
+            <div class="item-notify" ?hidden=${!notify || hideNotify} style=${`--vic-notify-color: ${notifyColor}`}>
+              <ha-icon icon=${notifyIcon}></ha-icon>
             </div>
           </div>
           <div class="item-content">

--- a/src/css/card.css
+++ b/src/css/card.css
@@ -400,8 +400,7 @@ header h1 {
   top: -2px;
   right: -3px;
   line-height: 0;
-  color: #db4437;
-  color: var(--error-color, #db4437);
+  color: var(--vic-notify-color, var(--error-color));
   --mdc-icon-size: 1.35rem;
   justify-content: center;
   align-items: center;

--- a/src/editor/form/base-button-schema.ts
+++ b/src/editor/form/base-button-schema.ts
@@ -93,6 +93,12 @@ export const BASE_BUTTON_APPEARANCE_SCHEMA = memoizeOne(
             title: 'Advanced Options',
             schema: [
               {
+                name: 'color',
+                label: 'Color icon template',
+                helper: 'Template for the icon color',
+                selector: { template: {} },
+              },
+              {
                 name: 'picture_template',
                 label: 'Picture & Icon template',
                 helper:
@@ -100,16 +106,29 @@ export const BASE_BUTTON_APPEARANCE_SCHEMA = memoizeOne(
                 selector: { template: {} },
               },
               {
-                name: 'notify',
-                label: 'Notification Badge template',
-                helper: 'Use Jinja2 template with result `true` to display notification badge',
-                selector: { template: {} },
-              },
-              {
-                name: 'color',
-                label: 'Color template',
-                helper: 'Template for the icon color',
-                selector: { template: {} },
+                name: '',
+                type: 'expandable',
+                title: 'Notification Badge Options',
+                schema: [
+                  {
+                    name: 'notify',
+                    label: 'Notification Badge visibility template',
+                    helper: 'Use Jinja2 template with result `true` to display notification badge',
+                    selector: { template: {} },
+                  },
+                  {
+                    name: 'notify_color',
+                    label: 'Notification Badge color template',
+                    helper: 'Use Jinja2 template to set the badge color',
+                    selector: { template: {} },
+                  },
+                  {
+                    name: 'notify_icon',
+                    label: 'Notification Badge icon template',
+                    helper: 'Template with result in `mdi:` format to set the badge icon',
+                    selector: { template: {} },
+                  },
+                ],
               },
             ],
           },

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -129,6 +129,8 @@ type SecondaryInfoConfig = {
 export interface ButtonConfig {
   icon: string;
   notify?: string;
+  notify_color?: string;
+  notify_icon?: string;
   primary: string;
   color: string;
   secondary: SecondaryInfoConfig;
@@ -235,6 +237,8 @@ export interface ButtonCardEntityItem {
     secondary: SecondaryInfoConfig;
     color: string;
     picture_template: string;
+    notify_color?: string;
+    notify_icon?: string;
   };
   button_type: BUTTON_TYPE;
   card_type: CARD_TYPE;

--- a/src/utils/ha-helper.ts
+++ b/src/utils/ha-helper.ts
@@ -157,6 +157,8 @@ export async function getButtonCard(hass: HomeAssistant, buttonConfig: ButtonCar
       button_action: btnCrd.button_action,
       icon: button.icon || '',
       notify: button.notify || '',
+      notify_color: button.notify_color || '',
+      notify_icon: button.notify_icon || '',
       primary: button.primary || '',
       secondary: button.secondary || [],
       color: button.color || '',


### PR DESCRIPTION
Introduce options for customizing the notification badge's color and icon in button configurations. Update the schema to include these new properties and adjust the rendering logic accordingly.