### PR TITLE
Fix: Adjust energy item display to include charging icon inside

### DIFF
--- a/src/components/shared/vsc-range-item.ts
+++ b/src/components/shared/vsc-range-item.ts
@@ -394,8 +394,8 @@ export class VscRangeItem extends LitElement {
         </ha-tooltip>
         <div class="fuel-wrapper">
           <div class="fuel-level-bar" style="width: ${level}%; background: ${barColor};" ?charging="${booleanChargingState}">
-            ${chargingIcon}
-            ${energyPosition === 'inside' ? html`<span id="energy-item">${energyState}</span>` : nothing}
+
+            ${energyPosition === 'inside' ? html`${chargingIcon}<span id="energy-item">${energyState}</span>` : nothing}
           </div>
           ${
             rangePosition === 'inside'


### PR DESCRIPTION
Modify the energy item display to show the charging icon when the energy position is set to inside.