### PR TITLE
Add range info bars layout configuration

### DIFF
--- a/src/components/vsc-range-info.ts
+++ b/src/components/vsc-range-info.ts
@@ -1,4 +1,4 @@
-import { CSSResultGroup, html, LitElement, PropertyValues, TemplateResult } from 'lit';
+import { css, CSSResultGroup, html, LitElement, PropertyValues, TemplateResult } from 'lit';
 import { customElement, state, property } from 'lit/decorators.js';
 
 import cardcss from '../css/card.css';
@@ -9,10 +9,40 @@ import './shared/vsc-range-item';
 export class VscRangeInfo extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
   @property({ attribute: false }) rangeConfig!: RangeInfoConfig[];
+  @property({ type: Boolean, reflect: true }) public row = false;
   @state() public _groupIndicatorActive: number | null = null;
 
   static get styles(): CSSResultGroup {
-    return [cardcss];
+    return [
+      css`
+        .combined-info-box[row] {
+          display: flex;
+          flex-direction: column;
+          gap: var(--vic-gutter-gap);
+        }
+        .combined-info-box {
+          display: grid;
+          width: 100%;
+          grid-template-columns: repeat(auto-fill, minmax(49%, 1fr));
+          column-gap: 0.5rem;
+          opacity: 1;
+          transition: all 400ms cubic-bezier(0.3, 0, 0.8, 0.15);
+          max-height: 1000px;
+          padding: 0px;
+        }
+
+        .combined-info-box.not-visible {
+          opacity: 0;
+          padding-top: var(--vic-card-padding);
+          max-height: 0;
+          overflow: hidden;
+          /* transition: padding-top 400ms linear, max-height 400ms cubic-bezier(0.3, 0.0, 0.8, 0.15); */
+          transition: all 400ms cubic-bezier(0.3, 0, 0.8, 0.15);
+          transition-delay: 400ms;
+        }
+      `,
+      cardcss,
+    ];
   }
 
   protected async firstUpdated(changeProperties: PropertyValues): Promise<void> {
@@ -27,7 +57,7 @@ export class VscRangeInfo extends LitElement {
     });
 
     // Wrap rangeInfo in a div if there are more than one entries
-    return html`<div class=${_class}>${rangeInfo}</div>`;
+    return html`<div class=${_class} ?row=${this.row}>${rangeInfo}</div>`;
   }
 
   public _handleIndicatorClick(index: number | null): void {

--- a/src/css/card.css
+++ b/src/css/card.css
@@ -140,29 +140,6 @@ header h1 {
   flex-direction: column;
 }
 
-.combined-info-box {
-  display: grid;
-  width: 100%;
-  /* height: -moz-fit-content;
-  height: 100%; */
-  grid-template-columns: repeat(auto-fill, minmax(49%, 1fr));
-  column-gap: 0.5rem;
-  opacity: 1;
-  transition: all 400ms cubic-bezier(0.3, 0.0, 0.8, 0.15);
-  max-height: 1000px;
-  padding: 0px;
-}
-
-.combined-info-box.not-visible {
-  opacity: 0;
-  padding-top: var(--vic-card-padding);
-  max-height: 0;
-  overflow: hidden;
-  /* transition: padding-top 400ms linear, max-height 400ms cubic-bezier(0.3, 0.0, 0.8, 0.15); */
-  transition: all 400ms cubic-bezier(0.3, 0.0, 0.8, 0.15);
-  transition-delay: 0.3s;
-}
-
 
 .info-box {
   --mdc-icon-size: 20px;

--- a/src/editor/components/panel-button-card.ts
+++ b/src/editor/components/panel-button-card.ts
@@ -262,7 +262,7 @@ export class PanelButtonCard extends LitElement {
     return html`
       <div class="card-config">
         ${this._renderHeader(
-          `#${buttonIndex + 1}: ${button.primary.toUpperCase()}`,
+          `#${buttonIndex + 1}: ${button.primary?.toUpperCase() ?? ''}`,
           `${button.icon}`,
 
           this._yamlEditorActive

--- a/src/editor/form/base-button-schema.ts
+++ b/src/editor/form/base-button-schema.ts
@@ -71,13 +71,19 @@ export const BASE_BUTTON_APPEARANCE_SCHEMA = memoizeOne(
             expanded: true,
             schema: [
               {
-                name: 'entity',
-                selector: { entity: {} },
-              },
-              {
-                name: 'attribute',
-                label: 'Attribute',
-                selector: { attribute: { entity_id: secondEntity } },
+                name: '',
+                type: 'grid',
+                schema: [
+                  {
+                    name: 'entity',
+                    selector: { entity: {} },
+                  },
+                  {
+                    name: 'attribute',
+                    label: 'Attribute',
+                    selector: { attribute: { entity_id: secondEntity } },
+                  },
+                ],
               },
               {
                 name: 'state_template',

--- a/src/editor/form/range-config-schema.ts
+++ b/src/editor/form/range-config-schema.ts
@@ -148,3 +148,15 @@ export const CHARGE_TARGET_SCHEMA = [
     selector: { template: {} },
   },
 ];
+
+const RANGE_LAYOUTS = ['column', 'row'] as const;
+export const RANGE_LAYOUT_SCHEMA = [
+  {
+    name: 'layout',
+    label: 'Layout appearance',
+    type: 'select',
+    default: 'column',
+    required: false,
+    options: RANGE_LAYOUTS.map((layout) => [layout, layout.charAt(0).toUpperCase() + layout.slice(1)]),
+  },
+] as const;

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -303,6 +303,9 @@ export interface LayoutConfig {
     theme?: string;
   };
   section_order?: Array<string>;
+  range_info_config?: {
+    layout: 'column' | 'row';
+  };
 }
 
 /**

--- a/src/vehicle-status-card.ts
+++ b/src/vehicle-status-card.ts
@@ -299,13 +299,13 @@ export class VehicleStatusCard extends LitElement implements LovelaceCard {
   private _renderRangeInfo(): TemplateResult {
     const { range_info } = this._config;
     if (!range_info) return html``;
-
+    const rangeLayout = this._config.layout_config?.range_info_config?.layout || 'column';
     return html`<div
       id="range"
       ?noMargin=${!this._config.indicators || this._isSectionHidden(SECTION.INDICATORS)}
       ?hidden=${this._isSectionHidden(SECTION.RANGE_INFO) || !range_info}
     >
-      <vsc-range-info .hass=${this._hass} .rangeConfig=${range_info}></vsc-range-info>
+      <vsc-range-info .hass=${this._hass} .rangeConfig=${range_info} ?row=${rangeLayout === 'row'}></vsc-range-info>
     </div>`;
   }
 


### PR DESCRIPTION
Introduce a new configuration option for range layout, allowing users to choose between column and row layouts. Update the display logic to reflect the selected layout in the range information component.

![CleanShot 2025-06-06 at 18 03 41](https://github.com/user-attachments/assets/77216a92-3f57-4b37-b6bd-8dc6ea8f0c3f)
