### PR TITLE
Set max-width to 100% for range energy level display

### DIFF
--- a/src/components/shared/vsc-range-item.ts
+++ b/src/components/shared/vsc-range-item.ts
@@ -60,6 +60,7 @@ export class VscRangeItem extends LitElement {
           padding-inline: var(--vic-card-padding);
           box-sizing: border-box;
           min-width: fit-content;
+          max-width: 100% !important;
         }
         .fuel-level-bar[charging] {
           justify-content: space-between;


### PR DESCRIPTION
Adjust the styling to ensure the range energy level component does not exceed the width of its container.