### PR TITLE
feat(custom-background): Add custom background configuration to layout

### DIFF
--- a/src/editor/components/panel-layout-editor.ts
+++ b/src/editor/components/panel-layout-editor.ts
@@ -14,6 +14,7 @@ import {
   HIDE_CARD_NAME_SCHEMA,
   IMAGES_LAYOUT_SCHEMA,
   SINGLE_TIRE_ENABLED_SCHEMA,
+  CUSTOM_BACKGROUND_SCHEMA,
 } from '../form';
 
 @customElement(PANEL.LAYOUT_EDITOR)
@@ -46,6 +47,7 @@ export class PanelLayoutEditor extends BaseEditor {
       BUTTON_GRID_LAYOUT_SCHEMA(!LAYOUT_DATA.button_grid?.swipe, 'button_grid'),
       IMAGES_LAYOUT_SCHEMA(LAYOUT_DATA.images_swipe, 'images_swipe'),
       CARD_THEME_SCHEMA,
+      CUSTOM_BACKGROUND_SCHEMA,
     ].map((schema) => this._createVscForm(LAYOUT_DATA, schema, 'layout_config'));
 
     const singleTireSection = this._renderSingleTireConfig(LAYOUT_DATA);

--- a/src/editor/form/layout-config-schema.ts
+++ b/src/editor/form/layout-config-schema.ts
@@ -145,3 +145,71 @@ export const CARD_THEME_SCHEMA = [
     ],
   },
 ] as const;
+
+const BG_SIZE = ['cover', 'contain', 'auto'] as const;
+const BG_POSITION = [
+  'left',
+  'center',
+  'right',
+  'top',
+  'bottom',
+  'top left',
+  'top right',
+  'bottom left',
+  'bottom right',
+] as const;
+export const CUSTOM_BACKGROUND_SCHEMA = [
+  {
+    title: 'Custom Background',
+    name: 'custom_background',
+    type: 'expandable',
+    flatten: false,
+    icon: 'mdi:image-multiple',
+    schema: [
+      {
+        name: 'url',
+        label: 'Background Image',
+        required: false,
+        selector: {
+          media: {
+            accept: ['image/*'] as string[],
+            clearable: true,
+            image_upload: true,
+            hide_content_type: false,
+          },
+        },
+      },
+      {
+        name: 'size',
+        label: 'Background Size',
+        required: false,
+        default: 'cover',
+        selector: {
+          select: {
+            mode: 'dropdown',
+            custom_value: true,
+            options: BG_SIZE.map((size) => ({
+              value: size,
+              label: capitalizeFirstLetter(size),
+            })),
+          },
+        },
+      },
+      {
+        name: 'position',
+        label: 'Background Position',
+        required: false,
+        default: 'center',
+        selector: {
+          select: {
+            mode: 'dropdown',
+            options: BG_POSITION.map((position) => ({
+              value: position,
+              label: capitalizeFirstLetter(position),
+            })),
+          },
+        },
+      },
+    ],
+  },
+] as const;

--- a/src/types/config/card/layout.ts
+++ b/src/types/config/card/layout.ts
@@ -1,3 +1,4 @@
+import { MediaSelectorValue } from '../../../ha/data/media_source';
 import { TireTemplateConfig } from './tire-card';
 
 // List of all section keys
@@ -18,6 +19,7 @@ export interface LayoutConfig {
     tire_card?: TireTemplateConfig;
   };
   hide_card_name?: boolean;
+  custom_background?: BackgroundImageConfig;
   /**
    * @deprecated is replaced by 'section_order' option
    */
@@ -92,3 +94,21 @@ export const hasButtonGridLegacy = (btnConfig?: ButtonGridConfig): boolean => {
     btnConfig.hide_notify_badge !== undefined
   );
 };
+
+type BACKGROUND_SIZE = 'cover' | 'contain' | 'auto';
+type BACKGROUND_POSITION =
+  | 'left'
+  | 'center'
+  | 'right'
+  | 'top'
+  | 'bottom'
+  | 'top left'
+  | 'top right'
+  | 'bottom left'
+  | 'bottom right';
+
+export interface BackgroundImageConfig {
+  url: string | MediaSelectorValue;
+  size?: BACKGROUND_SIZE | string;
+  position?: BACKGROUND_POSITION;
+}


### PR DESCRIPTION
Introduce a custom background feature that allows users to set a background image, size, and position for the layout. This enhancement improves the visual customization options available in the editor.

<img width="1134" height="914" alt="image" src="https://github.com/user-attachments/assets/7d374744-2ad7-4a0a-816c-b3d5c4952527" />

closes: #240 
