### PR TITLE
feat(maptiler-map): Add show_history_control option to map configurations

### DIFF
--- a/src/types/config/card/mini-map.ts
+++ b/src/types/config/card/mini-map.ts
@@ -67,6 +67,7 @@ export interface MaptilerPopupConfig {
   map_styles?: CustomStyles;
   label_mode?: LABEL_MODE;
   attribute?: string;
+  show_history_control?: boolean;
 }
 
 export type MiniMapConfig = MiniMapBaseConfig & MinimapLayoutConfig & MapPopupSharedConfig & MaptilerPopupConfig;
@@ -96,6 +97,7 @@ export interface ExtraMapCardConfig extends BaseMapCardConfig {
   use_more_info?: boolean;
   custom_styles?: CustomStyles;
   history_period?: HISTORY_PERIOD;
+  show_history_control?: boolean;
 }
 
 export type LovelaceMapPopupConfig = MapCardConfig | ExtraMapCardConfig;
@@ -118,6 +120,7 @@ export function computeExtraMapConfig(config: MiniMapConfig): Partial<ExtraMapCa
     custom_styles: config.map_styles,
     history_period: config.history_period,
     use_more_info: config.use_more_info,
+    show_history_control: config.show_history_control,
     ...mapCommonPopupConfig(config),
   };
 }
@@ -153,6 +156,7 @@ export function toPopupShared(
     map_styles: config.custom_styles,
     history_period: config.history_period,
     use_more_info: config.use_more_info,
+    show_history_control: config.show_history_control,
   };
   return sharedConfig;
 }

--- a/src/vehicle-status-card.ts
+++ b/src/vehicle-status-card.ts
@@ -693,6 +693,7 @@ export class VehicleStatusCard extends BaseElement implements LovelaceCard {
           (mapTilerEl as any)._drawPaths();
           debug('extra map card path drawn');
         }
+        return;
       } else {
         debug('extra map card did not subscribe to history in time');
         return;


### PR DESCRIPTION
Introduce a new `show_history_control` option in map configurations to enhance user control over history display in the map. 

![time-range](https://github.com/user-attachments/assets/81412a7b-6265-427d-8aff-394408e644c3)

Closes: #236 
