### PR TITLE
fix(menu-button): change ha-button-menu to ha-dropdown

### DIFF
--- a/src/editor/components/panel-indicator-rows.ts
+++ b/src/editor/components/panel-indicator-rows.ts
@@ -15,7 +15,7 @@ import { ExpansionPanelParams } from '../../utils/editor/create';
 import { _renderActionItem, ActionType, ROW_MAIN_ACTIONS } from '../../utils/editor/create-actions-menu';
 import { computeNewRow } from '../../utils/editor/migrate-indicator';
 import { createSecondaryCodeLabel } from '../../utils/editor/sub-editor-header';
-import { preventDefault, stopAndPrevent, stopPropagation } from '../../utils/helpers-dom';
+import { preventDefault } from '../../utils/helpers-dom';
 import { ICON } from '../../utils/mdi-icons';
 import { BaseEditor } from '../base-editor';
 import { ELEMENT, PANEL, SUB_PANEL } from '../editor-const';
@@ -143,21 +143,13 @@ export class PanelIndicatorRows extends BaseEditor {
         @click=${this._handleRowAction}
       ></ha-icon-button>
       <div class="separator"></div>
-      <ha-button-menu
-        corner="BOTTOM_START"
-        menu-corner="END"
-        .fixed=${true}
-        .naturalMenuWidth=${true}
-        .activatable=${true}
-        @closed=${stopPropagation}
-        @opened=${stopAndPrevent}
-      >
+      <ha-dropdown placement="bottom-end">
         <ha-icon-button slot="trigger" .path=${ICON.DOTS_VERTICAL} @click=${preventDefault}> </ha-icon-button>
         ${ROW_MAIN_ACTIONS.map((item) => {
           if (/(delete|remove)/.test(item.action) && !deleteFound) {
             deleteFound = true;
             return html`
-              <li divider role="separator"></li>
+              <wa-divider></wa-divider>
               ${_renderActionItem({
                 item,
                 onClick: this._handleRowAction,
@@ -171,7 +163,7 @@ export class PanelIndicatorRows extends BaseEditor {
             option: { index: rowIndex },
           });
         })}
-      </ha-button-menu>
+      </ha-dropdown>
       <div class="separator"></div>
       <ha-svg-icon class="handle" .path=${ICON.DRAG} @click=${preventDefault}></ha-svg-icon>
     </div>`;

--- a/src/editor/shared/badge-editor-item.ts
+++ b/src/editor/shared/badge-editor-item.ts
@@ -154,36 +154,31 @@ export class BadgeEditorItem extends LitElement {
         ${this._menuAction.length === 1
           ? nothing
           : html`
-              <ha-button-menu
-                class="more"
-                corner="TOP_LEFT"
-                menu-corner="END"
-                .fixed=${true}
-                .naturalMenuWidth=${true}
-                .activatable=${true}
-                @closed=${(ev: Event) => {
+              <ha-dropdown
+                placement="top-left"
+                @wa-hide=${(ev: Event) => {
                   ev.stopPropagation();
                   this._menuOpened = false;
                 }}
-                @opened=${(ev: Event) => {
+                @wa-show=${(ev: Event) => {
                   ev.stopPropagation();
                   this._menuOpened = true;
                 }}
               >
-                <ha-icon-button slot="trigger" .path=${ICON.DOTS_VERTICAL}> </ha-icon-button>
+                <ha-icon-button slot="trigger" class="more" .path=${ICON.DOTS_VERTICAL}> </ha-icon-button>
                 ${this._menuAction.map((item) => {
                   if (isDelete(item.action) && !deleteFound) {
                     deleteFound = true;
                     return this.noDelete
                       ? nothing
                       : html`
-                          <li divider role="separator"></li>
+                          <wa-divider></wa-divider>
                           ${this._renderActionItem(item)}
                         `;
                   }
                   return this._renderActionItem(item);
                 })}
-              </ha-button-menu>
+              </ha-dropdown>
             `}
       </div>
     `;

--- a/src/utils/editor/create-actions-menu.ts
+++ b/src/utils/editor/create-actions-menu.ts
@@ -97,9 +97,10 @@ export const _renderActionItem = ({
 }): TemplateResult => {
   const deleteClass = /(delete|remove)/.test(item.action) ? 'error' : '';
   return html`
-    <ha-list-item
+    <ha-dropdown-item
       graphic="icon"
       .action=${item.action}
+      .value=${item.action}
       @click=${onClick}
       class=${deleteClass}
       .index=${option?.index}
@@ -109,10 +110,10 @@ export const _renderActionItem = ({
       <ha-icon
         class=${deleteClass}
         .icon=${item.icon}
-        slot="graphic"
+        slot="icon"
         style="${item.color ? `color: ${item.color}` : ''}"
       ></ha-icon>
       ${item.title}
-    </ha-list-item>
+    </ha-dropdown-item>
   `;
 };

--- a/src/utils/editor/menu-element.ts
+++ b/src/utils/editor/menu-element.ts
@@ -22,7 +22,7 @@ const DEFAULT = {
   description: CONFIG_TYPES.description,
 } as const;
 
-const OptionKeys = Object.keys(CONFIG_TYPES.options) as Array<keyof typeof CONFIG_TYPES.options>;
+// const OptionKeys = Object.keys(CONFIG_TYPES.options) as Array<keyof typeof CONFIG_TYPES.options>;
 
 type MenuSelectParams = {
   value?: string;
@@ -71,11 +71,8 @@ export class MenuElement extends BaseEditor {
               `
             : nothing}
 
-          <ha-button-menu
-            .fullWidth=${true}
-            .fixed=${true}
-            .activatable=${true}
-            .naturalMenuWidth=${true}
+          <ha-dropdown
+            placement="bottom-end"
             @closed=${(ev: Event) => {
               ev.stopPropagation();
               this._open = false;
@@ -84,18 +81,16 @@ export class MenuElement extends BaseEditor {
               ev.stopPropagation();
               this._open = true;
             }}
-            @action=${this._handleItemClick}
+            @wa-select=${this._handleItemClick}
           >
             <div id="menu-trigger" class="menu-icon click-shrink" slot="trigger">
               <div class="menu-icon-inner"><ha-icon .icon=${menuIcon}></ha-icon></div>
             </div>
 
             ${Object.entries(options).map(
-              ([key, o]) => html`
-                <ha-list-item .value=${key} .activated=${this.value === key}> ${o.name} </ha-list-item>
-              `
+              ([key, o]) => html` <ha-dropdown-item .value=${key}> ${o.name} </ha-dropdown-item> `
             )}
-          </ha-button-menu>
+          </ha-dropdown>
         </div>
         <div class="menu-label">
           ${isDefault
@@ -141,19 +136,12 @@ export class MenuElement extends BaseEditor {
           ></ha-icon-button>
         </div>
         <div class="move-sec">
-          <ha-button-menu
-            .fixed=${true}
-            .naturalMenuWidth=${true}
-            .corner=${'BOTTOM_END'}
-            .menuCorner=${'END'}
-            @closed=${stopPropagation}
-            @opened=${stopPropagation}
-          >
+          <ha-dropdown placement="bottom-end" @wa-hide=${stopPropagation} @wa-show=${stopPropagation}>
             <ha-icon-button slot="trigger" .label=${'Options & Help'} .path=${ICON.DOTS_VERTICAL}></ha-icon-button>
             ${CONFIG_AREA_ACTIONS.map((item) => {
               return _renderActionItem({ item, onClick: this._handleAreaMenuAction });
             })}
-          </ha-button-menu>
+          </ha-dropdown>
         </div>
       </div>
     `;
@@ -200,7 +188,7 @@ export class MenuElement extends BaseEditor {
   }
 
   private _handleItemClick(event: CustomEvent | string): void {
-    const selectedValue = typeof event === 'string' ? event : OptionKeys[event.detail.index];
+    const selectedValue = typeof event === 'string' ? event : (event.detail as any).item.value;
     const value = selectedValue !== 'default' ? selectedValue : '';
     fireEvent(this, 'menu-value-changed', { value });
   }


### PR DESCRIPTION
Replace instances of `ha-button-menu` with `ha-dropdown` to streamline the dropdown menu implementation across various components. This change enhances consistency and usability in the UI.

Fixes: #243