### PR TITLE
Add state icon color option in range progress bar

### DIFF
--- a/src/components/shared/range/vsc-range-item.ts
+++ b/src/components/shared/range/vsc-range-item.ts
@@ -2,11 +2,12 @@ import { css, CSSResultGroup, html, nothing, PropertyValues, TemplateResult } fr
 import { customElement } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
+import { _computeStateColor } from '../../../ha/common/entity/state_active';
 import { ActionsSharedConfig, hasItemAction, RangeItemConfig } from '../../../types/config';
 import { VscBaseRange } from '../../../utils/base-range';
 import { generateColorBlocks, generateGradient, getColorForLevel, getNormalizedValue } from '../../../utils/colors';
-import { addActions } from '../../../utils/lovelace/tap-action';
 import './vsc-range-bar';
+import { addActions } from '../../../utils/lovelace/tap-action';
 
 @customElement('vsc-range-item')
 export class VscRangeItem extends VscBaseRange {
@@ -60,7 +61,7 @@ export class VscRangeItem extends VscBaseRange {
 
     const entityMax = r.energy_level?.max_value
       ? r.energy_level.max_value
-      : hass.states?.[r.energy_level?.entity || '']?.attributes?.max ?? 100;
+      : (hass.states?.[r.energy_level?.entity || '']?.attributes?.max ?? 100);
 
     switch (key) {
       case 'icon':
@@ -123,7 +124,7 @@ export class VscRangeItem extends VscBaseRange {
       case 'targetChargeVisibility':
         return r.charge_target_visibility
           ? this._templateResults['charge_target_visibility']?.result.toString() === 'true'
-          : r.charge_target_entity ?? false;
+          : (r.charge_target_entity ?? false);
 
       case 'targetTooltip':
         return r.charge_target_tooltip || false;
@@ -163,10 +164,11 @@ export class VscRangeItem extends VscBaseRange {
               ? this.getValue('barBackground')
               : r.color_thresholds[0]?.color || this.getValue('barBackground')
             : r.color_thresholds && r.energy_level?.value_alignment === 'end'
-            ? getColorForLevel(r.color_thresholds, this.getValue('level'), entityMax) || this.getValue('barBackground')
-            : this.getValue('level') > 2
-            ? r.progress_color
-            : this.getValue('barBackground');
+              ? getColorForLevel(r.color_thresholds, this.getValue('level'), entityMax) ||
+                this.getValue('barBackground')
+              : this.getValue('level') > 2
+                ? r.progress_color
+                : this.getValue('barBackground');
 
         return currentColor;
       case 'rangeStateColor':
@@ -233,15 +235,23 @@ export class VscRangeItem extends VscBaseRange {
   private _renderLevelItem(type: 'energy' | 'range'): TemplateResult | typeof nothing {
     const levelState = type === 'energy' ? this.getValue('energyState') : this.getValue('rangeState');
     const levelConfig = type === 'energy' ? this._energyLevel : this._rangeLevel;
-    const { value_position, hide_icon, icon, entity } = levelConfig || {};
+    const { value_position, hide_icon, icon, entity, icon_state_color } = levelConfig || {};
     if (!levelState || value_position === 'off' || value_position === 'inside') {
       return nothing;
     }
     const levelStateObj = this.hass.states[entity!];
+    const iconColor = icon_state_color ? _computeStateColor(levelStateObj) : undefined;
     return html`
       <div class="item" id="${type}-item">
         ${!hide_icon
-          ? html` <ha-state-icon .hass=${this._hass} .stateObj=${levelStateObj} icon=${icon}></ha-state-icon> `
+          ? html`
+              <ha-state-icon
+                .hass=${this._hass}
+                .stateObj=${levelStateObj}
+                .icon=${icon}
+                style=${iconColor ? `color: ${iconColor};` : ''}
+              ></ha-state-icon>
+            `
           : nothing}
         <span>${levelState}</span>
         ${type === 'energy' ? this._renderChargingIcon() : nothing}
@@ -255,24 +265,22 @@ export class VscRangeItem extends VscBaseRange {
     const rangeInside = get('rangePosition') === 'inside';
     const insideItems: TemplateResult[] = [];
     if (enegyInside) {
-      insideItems.push(
-        html`
-          <div
-            slot="energy-level"
-            class="energy-inside-container"
-            ?charging=${get('chargingState')}
-            align=${get('energyAlignment')}
-          >
-            ${this._renderChargingIcon()}
-            <span id="energy-item" class="energy-inside">${get('energyState')}</span>
-          </div>
-        `
-      );
+      insideItems.push(html`
+        <div
+          slot="energy-level"
+          class="energy-inside-container"
+          ?charging=${get('chargingState')}
+          align=${get('energyAlignment')}
+        >
+          ${this._renderChargingIcon()}
+          <span id="energy-item" class="energy-inside">${get('energyState')}</span>
+        </div>
+      `);
     }
     if (rangeInside) {
-      insideItems.push(
-        html` <span id="range-item" class="range-inside" slot="range-level">${get('rangeState')}</span> `
-      );
+      insideItems.push(html`
+        <span id="range-item" class="range-inside" slot="range-level">${get('rangeState')}</span>
+      `);
     }
     return insideItems;
   }

--- a/src/components/shared/range/vsc-range-item.ts
+++ b/src/components/shared/range/vsc-range-item.ts
@@ -2,7 +2,7 @@ import { css, CSSResultGroup, html, nothing, PropertyValues, TemplateResult } fr
 import { customElement } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
-import { _computeStateColor } from '../../../ha/common/entity/state_active';
+import { computeStateColor } from '../../../ha/common/color/compute-state-color';
 import { ActionsSharedConfig, hasItemAction, RangeItemConfig } from '../../../types/config';
 import { VscBaseRange } from '../../../utils/base-range';
 import { generateColorBlocks, generateGradient, getColorForLevel, getNormalizedValue } from '../../../utils/colors';
@@ -240,7 +240,7 @@ export class VscRangeItem extends VscBaseRange {
       return nothing;
     }
     const levelStateObj = this.hass.states[entity!];
-    const iconColor = icon_state_color ? _computeStateColor(levelStateObj) : undefined;
+    const iconColor = icon_state_color ? computeStateColor(levelStateObj) : undefined;
     return html`
       <div class="item" id="${type}-item">
         ${!hide_icon

--- a/src/components/shared/vsc-tire-card.ts
+++ b/src/components/shared/vsc-tire-card.ts
@@ -32,6 +32,7 @@ export class VehicleTireCard extends BaseElement {
   constructor() {
     super();
   }
+
   connectedCallback(): void {
     super.connectedCallback();
   }
@@ -114,13 +115,13 @@ export class VehicleTireCard extends BaseElement {
     return element;
   }
 
-  private async _rebuildElement(elToReplace: LovelaceElement, config: LovelaceElementConfig): Promise<void> {
+  private _rebuildElement = async (elToReplace: LovelaceElement, config: LovelaceElementConfig): Promise<void> => {
     const newCardEl = await this._createElement(config);
     if (elToReplace.parentElement) {
       elToReplace.parentElement.replaceChild(newCardEl, elToReplace);
     }
     this._elements = this._elements!.map((curCardEl) => (curCardEl === elToReplace ? newCardEl : curCardEl));
-  }
+  };
   static get styles(): CSSResultGroup {
     return [super.styles, css``];
   }

--- a/src/editor/form/range-config-schema.ts
+++ b/src/editor/form/range-config-schema.ts
@@ -55,6 +55,13 @@ export const RANGE_ITEM_BASE_SCHEMA = () =>
       helper: 'Hide the icon even if set',
     },
     {
+      name: 'icon_state_color',
+      label: 'Icon State Color',
+      type: 'boolean',
+      default: false,
+      helper: 'Use the state color for the icon',
+    },
+    {
       name: 'value_position',
       label: 'Value Position',
       default: 'outside',

--- a/src/ha/common/color/compute-state-color.ts
+++ b/src/ha/common/color/compute-state-color.ts
@@ -1,0 +1,37 @@
+import { HassEntity } from 'home-assistant-js-websocket/dist/types';
+import memoizeOne from 'memoize-one';
+
+import { computeDomain } from '../..';
+import { hsv2rgb, rgb2hex, rgb2hsv } from '../../../utils';
+import { stateActive } from '../entity/state_active';
+import { stateColorCss } from '../entity/state_color';
+import { computeCssColor } from './compute-color';
+
+export const computeStateColor = memoizeOne((stateObj: HassEntity, color?: string) => {
+  if (!stateObj) {
+    return undefined;
+  }
+  // Use custom color if active
+  if (color) {
+    return stateActive(stateObj) ? computeCssColor(color) : undefined;
+  }
+
+  // Use light color if the light support rgb
+  if (computeDomain(stateObj.entity_id) === 'light' && stateObj.attributes.rgb_color) {
+    const hsvColor = rgb2hsv(stateObj.attributes.rgb_color);
+
+    // Modify the real rgb color for better contrast
+    if (hsvColor[1] < 0.4) {
+      // Special case for very light color (e.g: white)
+      if (hsvColor[1] < 0.1) {
+        hsvColor[2] = 225;
+      } else {
+        hsvColor[1] = 0.4;
+      }
+    }
+    return rgb2hex(hsv2rgb(hsvColor));
+  }
+
+  // Fallback to state color
+  return stateColorCss(stateObj);
+});

--- a/src/ha/common/entity/state_active.ts
+++ b/src/ha/common/entity/state_active.ts
@@ -1,12 +1,7 @@
 import type { HassEntity } from 'home-assistant-js-websocket';
 
-import memoizeOne from 'memoize-one';
-
-import { hsv2rgb, rgb2hex, rgb2hsv } from '../../../utils';
 import { isUnavailableState, OFF, UNAVAILABLE } from '../../data/entity';
-import { computeCssColor } from '../color/compute-color';
 import { computeDomain } from './compute_domain';
-import { stateColorCss } from './state_color';
 
 export function stateActive(stateObj: HassEntity, state?: string): boolean {
   const domain = computeDomain(stateObj.entity_id);
@@ -62,32 +57,3 @@ export function stateActive(stateObj: HassEntity, state?: string): boolean {
 
   return true;
 }
-
-export const _computeStateColor = memoizeOne((stateObj: HassEntity, color?: string) => {
-  if (!stateObj) {
-    return undefined;
-  }
-  // Use custom color if active
-  if (color) {
-    return stateActive(stateObj) ? computeCssColor(color) : undefined;
-  }
-
-  // Use light color if the light support rgb
-  if (computeDomain(stateObj.entity_id) === 'light' && stateObj.attributes.rgb_color) {
-    const hsvColor = rgb2hsv(stateObj.attributes.rgb_color);
-
-    // Modify the real rgb color for better contrast
-    if (hsvColor[1] < 0.4) {
-      // Special case for very light color (e.g: white)
-      if (hsvColor[1] < 0.1) {
-        hsvColor[2] = 225;
-      } else {
-        hsvColor[1] = 0.4;
-      }
-    }
-    return rgb2hex(hsv2rgb(hsvColor));
-  }
-
-  // Fallback to state color
-  return stateColorCss(stateObj);
-});

--- a/src/ha/common/entity/state_active.ts
+++ b/src/ha/common/entity/state_active.ts
@@ -1,7 +1,12 @@
 import type { HassEntity } from 'home-assistant-js-websocket';
 
+import memoizeOne from 'memoize-one';
+
+import { hsv2rgb, rgb2hex, rgb2hsv } from '../../../utils';
 import { isUnavailableState, OFF, UNAVAILABLE } from '../../data/entity';
+import { computeCssColor } from '../color/compute-color';
 import { computeDomain } from './compute_domain';
+import { stateColorCss } from './state_color';
 
 export function stateActive(stateObj: HassEntity, state?: string): boolean {
   const domain = computeDomain(stateObj.entity_id);
@@ -57,3 +62,32 @@ export function stateActive(stateObj: HassEntity, state?: string): boolean {
 
   return true;
 }
+
+export const _computeStateColor = memoizeOne((stateObj: HassEntity, color?: string) => {
+  if (!stateObj) {
+    return undefined;
+  }
+  // Use custom color if active
+  if (color) {
+    return stateActive(stateObj) ? computeCssColor(color) : undefined;
+  }
+
+  // Use light color if the light support rgb
+  if (computeDomain(stateObj.entity_id) === 'light' && stateObj.attributes.rgb_color) {
+    const hsvColor = rgb2hsv(stateObj.attributes.rgb_color);
+
+    // Modify the real rgb color for better contrast
+    if (hsvColor[1] < 0.4) {
+      // Special case for very light color (e.g: white)
+      if (hsvColor[1] < 0.1) {
+        hsvColor[2] = 225;
+      } else {
+        hsvColor[1] = 0.4;
+      }
+    }
+    return rgb2hex(hsv2rgb(hsvColor));
+  }
+
+  // Fallback to state color
+  return stateColorCss(stateObj);
+});

--- a/src/types/config/card/range-info.ts
+++ b/src/types/config/card/range-info.ts
@@ -23,6 +23,7 @@ export type RangeItemConfig = {
   hold_action?: ActionConfig;
   double_tap_action?: ActionConfig;
   hide_icon?: boolean;
+  icon_state_color?: boolean;
 };
 
 export type RangeInfoLayoutConfig = Partial<{

--- a/src/utils/base-indicator.ts
+++ b/src/utils/base-indicator.ts
@@ -26,6 +26,7 @@ import {
 import { toCommon, isEntity } from '../types/config/card/row-indicators';
 import { rgb2hex, rgb2hsv, hsv2rgb } from '../utils/colors';
 import { BaseElement } from './base-element';
+import { computeStateColor } from '../ha/common/color/compute-state-color';
 
 const cameraUrlWithWidthHeight = (base_url: string, width: number, height: number) =>
   `${base_url}&width=${width}&height=${height}`;
@@ -212,32 +213,7 @@ export class VscIndicatorItemBase<T extends IndicatorRowItem> extends BaseElemen
   }
 
   protected _computeStateColor = memoizeOne((stateObj: HassEntity, color?: string) => {
-    if (!stateObj) {
-      return undefined;
-    }
-    // Use custom color if active
-    if (color) {
-      return stateActive(stateObj) ? computeCssColor(color) : undefined;
-    }
-
-    // Use light color if the light support rgb
-    if (computeDomain(stateObj.entity_id) === 'light' && stateObj.attributes.rgb_color) {
-      const hsvColor = rgb2hsv(stateObj.attributes.rgb_color);
-
-      // Modify the real rgb color for better contrast
-      if (hsvColor[1] < 0.4) {
-        // Special case for very light color (e.g: white)
-        if (hsvColor[1] < 0.1) {
-          hsvColor[2] = 225;
-        } else {
-          hsvColor[1] = 0.4;
-        }
-      }
-      return rgb2hex(hsv2rgb(hsvColor));
-    }
-
-    // Fallback to state color
-    return stateColorCss(stateObj);
+    return computeStateColor(stateObj, color);
   });
 
   protected _renderIcon(stateObj: HassEntity): TemplateResult {

--- a/src/utils/lovelace/create-card-element.ts
+++ b/src/utils/lovelace/create-card-element.ts
@@ -55,7 +55,7 @@ export const loadVerticalStackCard = async (): Promise<void> => {
   }
 
   if (!customElements.get(VERTICAL_STACK_TAG)) {
-    helpers.createCardElement({
+    await helpers.createCardElement({
       type: 'vertical-stack',
       cards: [],
     });
@@ -104,7 +104,7 @@ export const loadPictureCardHelper = async (hass: HomeAssistant): Promise<void> 
 };
 
 export async function createHuiElement(elementConfig: LovelaceElementConfig): Promise<LovelaceElement> {
-  const element = (await helpers.createHuiElement(elementConfig)) as LovelaceElement;
+  const element = await helpers?.createHuiElement(elementConfig);
   if (element.tagName !== 'HUI-CONDITIONAL-ELEMENT') {
     element.classList.add('element');
   }


### PR DESCRIPTION
Introduce an option to use the state color for icons in the range progress bar. This enhancement allows for better visual representation based on the entity's state.

Closes: #258