### PR TITLE
Fix hidden indicator space release issue and enhance alignment handling

### DIFF
--- a/src/components/shared/indicator-row/vsc-indicator-item.ts
+++ b/src/components/shared/indicator-row/vsc-indicator-item.ts
@@ -1,4 +1,4 @@
-import { css, html, nothing, TemplateResult } from 'lit';
+import { css, html, nothing, PropertyValues, TemplateResult } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
@@ -30,7 +30,14 @@ export class VscIndicatorItem extends VscIndicatorItemBase<IndicatorEntityConfig
   @property({ type: Boolean, reflect: true }) public active = false;
   @property({ attribute: false }) private globalAppearance?: GlobalAppearanceConfig;
   @property({ type: Boolean, reflect: true, attribute: 'dimmed-in-editor' }) public dimmedInEditor = false;
+  @property({ type: Boolean, reflect: true, attribute: 'hidden' }) public hidden = false;
+
   @query(COMPONENT.INDICATOR_BADGE) _badge!: VscIndicatorBadge;
+
+  protected willUpdate(_changedProperties: PropertyValues): void {
+    super.willUpdate(_changedProperties);
+    this.hidden = !Boolean(this._visibility);
+  }
 
   private get _visibility(): boolean {
     return Boolean(this._getTemplateResult('visibility') ?? true);
@@ -40,9 +47,7 @@ export class VscIndicatorItem extends VscIndicatorItemBase<IndicatorEntityConfig
     if (!this._config || !this.hass) {
       return nothing;
     }
-    if (!Boolean(this._visibility)) {
-      return nothing;
-    }
+
     const isGroup = this.type === 'group';
     const hasGroupEntity = this._hasGroupEntity;
     const commonConfig = this.commonConfig;

--- a/src/components/shared/indicator-row/vsc-indicator-item.ts
+++ b/src/components/shared/indicator-row/vsc-indicator-item.ts
@@ -1,4 +1,4 @@
-import { css, html, nothing, PropertyValues, TemplateResult } from 'lit';
+import { css, html, nothing, TemplateResult } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
@@ -31,10 +31,6 @@ export class VscIndicatorItem extends VscIndicatorItemBase<IndicatorEntityConfig
   @property({ attribute: false }) private globalAppearance?: GlobalAppearanceConfig;
   @property({ type: Boolean, reflect: true, attribute: 'dimmed-in-editor' }) public dimmedInEditor = false;
   @query(COMPONENT.INDICATOR_BADGE) _badge!: VscIndicatorBadge;
-
-  protected willUpdate(_changedProperties: PropertyValues): void {
-    super.willUpdate(_changedProperties);
-  }
 
   private get _visibility(): boolean {
     return Boolean(this._getTemplateResult('visibility') ?? true);

--- a/src/components/shared/indicator-row/vsc-indicator-item.ts
+++ b/src/components/shared/indicator-row/vsc-indicator-item.ts
@@ -1,4 +1,4 @@
-import { css, html, nothing, TemplateResult } from 'lit';
+import { css, html, nothing, PropertyValues, TemplateResult } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
@@ -31,6 +31,10 @@ export class VscIndicatorItem extends VscIndicatorItemBase<IndicatorEntityConfig
   @property({ attribute: false }) private globalAppearance?: GlobalAppearanceConfig;
   @property({ type: Boolean, reflect: true, attribute: 'dimmed-in-editor' }) public dimmedInEditor = false;
   @query(COMPONENT.INDICATOR_BADGE) _badge!: VscIndicatorBadge;
+
+  protected willUpdate(_changedProperties: PropertyValues): void {
+    super.willUpdate(_changedProperties);
+  }
 
   private get _visibility(): boolean {
     return Boolean(this._getTemplateResult('visibility') ?? true);
@@ -163,6 +167,13 @@ export class VscIndicatorItem extends VscIndicatorItemBase<IndicatorEntityConfig
 
   static get styles() {
     return css`
+      :host[hidden] {
+        display: none;
+        max-height: 0;
+        max-width: 0;
+        overflow: hidden;
+      }
+
       :host([dimmed-in-editor]),
       :host(.dimmed) {
         opacity: 0.2;

--- a/src/editor/base-editor.ts
+++ b/src/editor/base-editor.ts
@@ -27,7 +27,7 @@ import {
   SLIDE_SIZE_SCHEMA,
   SWIPE_BEHAVIOR_SCHEMA,
 } from './form';
-
+import * as CardHelpers from '../utils/lovelace/create-card-element';
 const EditorCommandTypes = [
   'show-button',
   'show-image',
@@ -64,6 +64,7 @@ export class BaseEditor extends LitElement {
 
   protected _editorArea?: ConfigArea;
 
+  _utils = { CARD_HELPERS: CardHelpers };
   constructor(area?: ConfigArea) {
     super();
     this._stylesManager = new HomeAssistantStylesManager({
@@ -118,8 +119,8 @@ export class BaseEditor extends LitElement {
         section === SECTION.BUTTONS
           ? config.button_cards
           : section === SECTION.INDICATORS
-          ? config.indicator_rows
-          : config[section];
+            ? config.indicator_rows
+            : config[section];
       return !isEmpty(secConfig);
     });
   }

--- a/src/editor/base-editor.ts
+++ b/src/editor/base-editor.ts
@@ -27,7 +27,6 @@ import {
   SLIDE_SIZE_SCHEMA,
   SWIPE_BEHAVIOR_SCHEMA,
 } from './form';
-import * as CardHelpers from '../utils/lovelace/create-card-element';
 const EditorCommandTypes = [
   'show-button',
   'show-image',
@@ -64,7 +63,6 @@ export class BaseEditor extends LitElement {
 
   protected _editorArea?: ConfigArea;
 
-  _utils = { CARD_HELPERS: CardHelpers };
   constructor(area?: ConfigArea) {
     super();
     this._stylesManager = new HomeAssistantStylesManager({

--- a/src/editor/components/indicators/panel-row-item.ts
+++ b/src/editor/components/indicators/panel-row-item.ts
@@ -348,10 +348,6 @@ export class PanelIndicatorItem extends BaseEditor {
     const config = { ...(this._rowConfig || {}) } as IndicatorRowConfig;
     if (!config) return;
     if (key === 'alignment') {
-      // If the alignment is not set, and the config has no alignment, we should not do anything
-      if (!value && !config.alignment) {
-        return;
-      }
       // If the alignment is not set, and the config has an alignment, we should remove it
       if (!value && config.alignment) {
         delete config.alignment;

--- a/src/editor/components/indicators/panel-row-item.ts
+++ b/src/editor/components/indicators/panel-row-item.ts
@@ -110,7 +110,7 @@ export class PanelIndicatorItem extends BaseEditor {
                   label="Alignment (optional)"
                   .value=${this._rowConfig?.alignment}
                   .key=${'alignment'}
-                  @value-changed=${this._onValueChanged}
+                  @selected=${this._onValueChanged}
                 ></vsc-alignment-selector>
                 ${noWrapEl}
               </div>
@@ -342,6 +342,7 @@ export class PanelIndicatorItem extends BaseEditor {
 
   protected _onValueChanged(ev: CustomEvent): void {
     ev.stopPropagation();
+    console.debug('Value changed', ev, ev.target, ev.detail);
     const { key } = ev.target as any;
     const value = ev.detail?.value;
     // console.debug('Value changed', key, subKey, value);

--- a/src/editor/components/slide-images/panel-images-editor.ts
+++ b/src/editor/components/slide-images/panel-images-editor.ts
@@ -9,7 +9,6 @@ import { showImageUploadDialog } from '../../../ha/dialogs/image-upload/show-ima
 import { ImageItem, VehicleStatusCardConfig } from '../../../types/config';
 import { ConfigArea } from '../../../types/config-area';
 import { ICON } from '../../../utils';
-import { loadPictureCardHelper } from '../../../utils/lovelace/create-card-element';
 import { BaseEditor } from '../../base-editor';
 import { PANEL } from '../../editor-const';
 
@@ -36,7 +35,6 @@ export class PanelImagesEditor extends BaseEditor {
 
   connectedCallback() {
     super.connectedCallback();
-    void loadPictureCardHelper(this._hass!);
   }
 
   disconnectedCallback(): void {
@@ -71,14 +69,15 @@ export class PanelImagesEditor extends BaseEditor {
       >
       <span slot="secondary-action">
         ${ActiveViews.map(
-          (view) => html` <ha-icon-button
-            class="view-button"
-            .viewType=${view}
-            ?active=${isActive(view)}
-            .path=${VIEW_ICON[view]}
-            @click=${this._handleViewChange}
-          >
-          </ha-icon-button>`
+          (view) =>
+            html` <ha-icon-button
+              class="view-button"
+              .viewType=${view}
+              ?active=${isActive(view)}
+              .path=${VIEW_ICON[view]}
+              @click=${this._handleViewChange}
+            >
+            </ha-icon-button>`
         )}
       </span>
     </sub-editor-header>`;

--- a/src/editor/editor.ts
+++ b/src/editor/editor.ts
@@ -21,7 +21,6 @@ import { MenuElement } from '../utils/editor/menu-element';
 import { migrateLegacyIndicatorsConfig } from '../utils/editor/migrate-indicator';
 // Import struct
 import { selectTree } from '../utils/helpers-dom';
-import { loadPictureCard } from '../utils/lovelace/create-card-element';
 import { Store } from '../utils/store';
 import { VehicleStatusCard } from '../vehicle-status-card';
 import { BaseEditor } from './base-editor';
@@ -73,7 +72,6 @@ export class VehicleStatusCardEditor extends BaseEditor implements LovelaceCardE
 
   connectedCallback() {
     super.connectedCallback();
-    void loadPictureCard();
     void loadHaComponents();
     void refactorEditDialog();
     window.EditorManager = this;

--- a/src/ha/dialogs/image-upload/vsc-image-upload.ts
+++ b/src/ha/dialogs/image-upload/vsc-image-upload.ts
@@ -68,11 +68,12 @@ export class VscImageUpload extends LitElement implements HassDialog<ImageUpload
   @state() private _data: ImageUploadDialogData = {};
 
   @state() private _imageEntities: string[] = [];
-  @state() private _imageUrls: string[] = [];
+  @state() private _imageUrls: ImageItem['image'][] = [];
 
   @state() private _uploading = false;
 
   @query('ha-file-upload') _fileUpload!: any;
+
   public async showDialog(params: ImageUploadDialogParams): Promise<void> {
     this._params = params;
     this._data = params.data || {};
@@ -199,6 +200,19 @@ export class VscImageUpload extends LitElement implements HassDialog<ImageUpload
     `;
   }
 
+  // render the ha-selector with media source selector to load the image upload form, but keep it hidden.
+  private _renderFileUploadForm() {
+    const selector = {
+      media: {
+        accept: ['image/*'] as string[],
+        clearable: true,
+        image_upload: true,
+        hide_content_type: false,
+      },
+    };
+    return html` <ha-selector .hass=${this.hass} .selector=${selector} hidden> </ha-selector> `;
+  }
+
   private _renderFileUpload(): TemplateResult {
     const secondary = html`${this.hass!.localize('ui.components.picture-upload.secondary', {
       select_media: html`<button class="link" @click=${this._showMediaBrowser}>
@@ -206,6 +220,7 @@ export class VscImageUpload extends LitElement implements HassDialog<ImageUpload
       </button>`,
     })}`;
     return html`
+      ${this._renderFileUploadForm()}
       <ha-file-upload
         .hass=${this.hass}
         .icon=${mdiImagePlus}
@@ -222,7 +237,7 @@ export class VscImageUpload extends LitElement implements HassDialog<ImageUpload
 
   private _renderImageUrlsEditor(): TemplateResult {
     const urlsData = {
-      urls: this._imageUrls.map((url) => ({ image: url })),
+      urls: this._imageUrls.map((url) => ({ image: typeof url === 'object' ? url.metadata?.thumbnail || '' : url })),
     };
 
     const urlsContent = html`

--- a/src/types/config/card/row-indicators.ts
+++ b/src/types/config/card/row-indicators.ts
@@ -84,9 +84,12 @@ export interface GlobalAppearanceConfig {
  * into a single row configuration.
  */
 
+export const ALIGNMENT = ['default', 'start', 'center', 'end', 'justify'] as const;
+export type Alignment = (typeof ALIGNMENT)[number];
+
 export interface IndicatorRowConfig extends GlobalAppearanceConfig {
   row_items: IndicatorRowItem[]; // Array of indicator items in the row
-  alignment?: string;
+  alignment?: Alignment;
   no_wrap?: boolean;
 }
 

--- a/src/utils/editor/alignment-selector.ts
+++ b/src/utils/editor/alignment-selector.ts
@@ -3,9 +3,7 @@ import { customElement, property } from 'lit/decorators.js';
 
 import { HomeAssistant } from '../../ha';
 import { capitalizeFirstLetter } from '../../ha/common/string/capitalize-first-letter';
-
-const ALIGNMENT = ['default', 'start', 'center', 'end', 'justify'] as const;
-type Alignment = (typeof ALIGNMENT)[number];
+import { ALIGNMENT, Alignment } from '../../types/config/card/row-indicators';
 
 const ICONS: Record<Alignment, string> = {
   default: 'mdi:format-align-left',
@@ -19,7 +17,7 @@ const ICONS: Record<Alignment, string> = {
 export class AlignmentSelector extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
   @property() public label = '';
-  @property() public value?: string;
+  @property() public value?: Alignment;
   @property() public configValue = '';
 
   render() {
@@ -31,7 +29,6 @@ export class AlignmentSelector extends LitElement {
         .label=${this.label}
         .configValue=${this.configValue}
         .value=${this.value || 'default'}
-        @selected=${this._selectedChange}
         @closed=${(ev: any) => ev.stopPropagation()}
         fixedMenuPosition
         naturalMenuWidth
@@ -39,7 +36,14 @@ export class AlignmentSelector extends LitElement {
         <ha-icon slot="icon" .icon=${ICONS[value as Alignment]}></ha-icon>
         ${ALIGNMENT.map((alignment) => {
           return html`
-            <ha-list-item .value=${alignment} graphic="icon">
+            <ha-list-item
+              .value=${alignment}
+              graphic="icon"
+              @click=${(ev: Event) => {
+                ev.stopPropagation();
+                this._selectedChange(ev);
+              }}
+            >
               ${capitalizeFirstLetter(alignment)}
               <ha-icon slot="graphic" .icon=${ICONS[alignment]}></ha-icon>
             </ha-list-item>
@@ -50,13 +54,15 @@ export class AlignmentSelector extends LitElement {
   }
 
   _selectedChange(ev: Event) {
-    const value = (ev.target as HTMLSelectElement).value;
+    const value = (ev.target as any).value;
     if (value) {
       this.dispatchEvent(
         new CustomEvent('value-changed', {
           detail: {
-            value: value !== 'default' ? value : '',
+            value: value,
           },
+          bubbles: true,
+          composed: true,
         })
       );
     }

--- a/src/utils/editor/alignment-selector.ts
+++ b/src/utils/editor/alignment-selector.ts
@@ -1,3 +1,10 @@
+import {
+  mdiAlignHorizontalDistribute,
+  mdiFormatAlignCenter,
+  mdiFormatAlignJustify,
+  mdiFormatAlignLeft,
+  mdiFormatAlignRight,
+} from '@mdi/js';
 import { css, CSSResultGroup, html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
@@ -5,13 +12,27 @@ import { HomeAssistant } from '../../ha';
 import { capitalizeFirstLetter } from '../../ha/common/string/capitalize-first-letter';
 import { ALIGNMENT, Alignment } from '../../types/config/card/row-indicators';
 
+interface HaSelectOption {
+  value: string | number;
+  label?: string;
+  secondary?: string;
+  iconPath?: string;
+  disabled?: boolean;
+}
+
 const ICONS: Record<Alignment, string> = {
-  default: 'mdi:format-align-left',
-  start: 'mdi:format-align-left',
-  center: 'mdi:format-align-center',
-  end: 'mdi:format-align-right',
-  justify: 'mdi:format-align-justify',
+  default: mdiAlignHorizontalDistribute,
+  start: mdiFormatAlignLeft,
+  center: mdiFormatAlignCenter,
+  end: mdiFormatAlignRight,
+  justify: mdiFormatAlignJustify,
 };
+
+const ALIGNMENT_OPTIONS: HaSelectOption[] = ALIGNMENT.map((alignment) => ({
+  value: alignment,
+  label: capitalizeFirstLetter(alignment),
+  iconPath: ICONS[alignment],
+}));
 
 @customElement('vsc-alignment-selector')
 export class AlignmentSelector extends LitElement {
@@ -19,53 +40,24 @@ export class AlignmentSelector extends LitElement {
   @property() public label = '';
   @property() public value?: Alignment;
   @property() public configValue = '';
+  @property() _selectedChange = (): void => {};
 
   render() {
     const value = this.value || 'default';
 
     return html`
       <ha-select
-        icon
         .label=${this.label}
         .configValue=${this.configValue}
-        .value=${this.value || 'default'}
+        .value=${value}
+        @selected=${this._selectedChange}
         @closed=${(ev: any) => ev.stopPropagation()}
+        .options=${ALIGNMENT_OPTIONS}
         fixedMenuPosition
         naturalMenuWidth
       >
-        <ha-icon slot="icon" .icon=${ICONS[value as Alignment]}></ha-icon>
-        ${ALIGNMENT.map((alignment) => {
-          return html`
-            <ha-list-item
-              .value=${alignment}
-              graphic="icon"
-              @click=${(ev: Event) => {
-                ev.stopPropagation();
-                this._selectedChange(ev);
-              }}
-            >
-              ${capitalizeFirstLetter(alignment)}
-              <ha-icon slot="graphic" .icon=${ICONS[alignment]}></ha-icon>
-            </ha-list-item>
-          `;
-        })}
       </ha-select>
     `;
-  }
-
-  _selectedChange(ev: Event) {
-    const value = (ev.target as any).value;
-    if (value) {
-      this.dispatchEvent(
-        new CustomEvent('value-changed', {
-          detail: {
-            value: value,
-          },
-          bubbles: true,
-          composed: true,
-        })
-      );
-    }
   }
 
   static get styles(): CSSResultGroup {

--- a/src/utils/editor/show-dialog-box.ts
+++ b/src/utils/editor/show-dialog-box.ts
@@ -1,14 +1,6 @@
 import { TemplateResult } from 'lit';
 
 import { NAMESPACE_TITLE } from '../../constants/const';
-const HELPERS = (window as any).loadCardHelpers ? (window as any).loadCardHelpers() : undefined;
-
-let helpers: any;
-if ((window as any).loadCardHelpers) {
-  helpers = await (window as any).loadCardHelpers();
-} else if (HELPERS) {
-  helpers = HELPERS;
-}
 
 export const showConfirmDialog = async (
   element: HTMLElement,
@@ -52,7 +44,7 @@ export const showPromptDialog = async (
       title: NAMESPACE_TITLE,
       text,
       placeholder,
-      confirmText,
+      confirmText: confirmText ?? 'Add',
       inputType: 'string',
       defaultValue: '',
       cancelText: cancelText ? cancelText : 'Cancel',

--- a/src/utils/editor/show-dialog-box.ts
+++ b/src/utils/editor/show-dialog-box.ts
@@ -77,7 +77,7 @@ export const showAlertDialog = async (element: HTMLElement, message: string | Te
   // Fallback for HA 2026.2+ where loadCardHelpers is not available
   // Use the native alert dialog
   return new Promise<void>((resolve) => {
-    window.alert(`${NAMESPACE_TITLE}\n\n${message}`);
+    window.alert(`${NAMESPACE_TITLE}\n\n${typeof message === 'string' ? message : ''}`);
     resolve();
   });
 };

--- a/src/utils/editor/show-dialog-box.ts
+++ b/src/utils/editor/show-dialog-box.ts
@@ -2,6 +2,7 @@ import { TemplateResult } from 'lit';
 
 import { NAMESPACE_TITLE } from '../../constants/const';
 const HELPERS = (window as any).loadCardHelpers ? (window as any).loadCardHelpers() : undefined;
+
 let helpers: any;
 if ((window as any).loadCardHelpers) {
   helpers = await (window as any).loadCardHelpers();
@@ -15,15 +16,26 @@ export const showConfirmDialog = async (
   confirmText: string,
   cancelText?: string
 ): Promise<boolean> => {
-  const result = await helpers.showConfirmationDialog(element, {
-    title: NAMESPACE_TITLE,
-    text: message,
-    confirmText,
-    dismissText: cancelText ? cancelText : 'Cancel',
-  });
+  // Check if loadCardHelpers is available (older HA versions)
+  if (typeof (window as any).loadCardHelpers === 'function') {
+    const helpers = await (window as any).loadCardHelpers();
+    const result = await helpers.showConfirmationDialog(element, {
+      title: NAMESPACE_TITLE,
+      text: message,
+      confirmText,
+      dismissText: cancelText ? cancelText : 'Cancel',
+    });
 
-  console.log('showConfirmDialog', result);
-  return result;
+    console.log('showConfirmDialog', result);
+    return result;
+  }
+
+  // Fallback for HA 2026.2+ where loadCardHelpers is not available
+  // Use the native confirm dialog
+  return new Promise<boolean>((resolve) => {
+    const confirmed = window.confirm(`${NAMESPACE_TITLE}\n\n${message}`);
+    resolve(confirmed);
+  });
 };
 
 export const showPromptDialog = async (
@@ -33,24 +45,47 @@ export const showPromptDialog = async (
   confirmText?: string,
   cancelText?: string
 ): Promise<string | null> => {
-  const result = await helpers.showPromptDialog(element, {
-    title: NAMESPACE_TITLE,
-    text,
-    placeholder,
-    confirmText: confirmText ? confirmText : 'Add',
-    inputType: 'string',
-    defaultValue: '',
-    cancelText: cancelText ? cancelText : 'Cancel',
-    confirmation: true,
-  });
+  // Check if loadCardHelpers is available (older HA versions)
+  if (typeof (window as any).loadCardHelpers === 'function') {
+    const helpers = await (window as any).loadCardHelpers();
+    const result = await helpers.showPromptDialog(element, {
+      title: NAMESPACE_TITLE,
+      text,
+      placeholder,
+      confirmText,
+      inputType: 'string',
+      defaultValue: '',
+      cancelText: cancelText ? cancelText : 'Cancel',
+      confirmation: true,
+    });
 
-  console.log('showPromptDialog', result);
-  return result;
+    console.log('showPromptDialog', result);
+    return result;
+  }
+
+  // Fallback for HA 2026.2+ where loadCardHelpers is not available
+  // Use the native prompt dialog
+  return new Promise<string | null>((resolve) => {
+    const result = window.prompt(`${NAMESPACE_TITLE}\n\n${text}`, placeholder);
+    resolve(result);
+  });
 };
 
 export const showAlertDialog = async (element: HTMLElement, message: string | TemplateResult): Promise<void> => {
-  await helpers.showAlertDialog(element, {
-    title: NAMESPACE_TITLE,
-    text: message,
+  // Check if loadCardHelpers is available (older HA versions)
+  if (typeof (window as any).loadCardHelpers === 'function') {
+    const helpers = await (window as any).loadCardHelpers();
+    await helpers.showAlertDialog(element, {
+      title: NAMESPACE_TITLE,
+      text: message,
+    });
+    return;
+  }
+
+  // Fallback for HA 2026.2+ where loadCardHelpers is not available
+  // Use the native alert dialog
+  return new Promise<void>((resolve) => {
+    window.alert(`${NAMESPACE_TITLE}\n\n${message}`);
+    resolve();
   });
 };

--- a/src/utils/lovelace/create-card-element.ts
+++ b/src/utils/lovelace/create-card-element.ts
@@ -4,14 +4,7 @@ import { HomeAssistant } from '../../ha';
 import { LovelaceElement, LovelaceElementConfig } from '../../ha/panels/lovelace/elements/types';
 
 let helpers = (window as any).cardHelpers;
-const helperPromise = new Promise<void>(async (resolve) => {
-  if (helpers) resolve();
-  if ((window as any).loadCardHelpers) {
-    helpers = await (window as any).loadCardHelpers();
-    (window as any).cardHelpers = helpers;
-    resolve();
-  }
-});
+
 /**
  *
  * @param hass Home Assistant instance
@@ -60,48 +53,6 @@ export const loadVerticalStackCard = async (): Promise<void> => {
       cards: [],
     });
   }
-};
-
-const HUI_PICTURE_CARD = 'hui-picture-card';
-export const loadPictureCard = async (): Promise<void> => {
-  if (customElements.get(HUI_PICTURE_CARD)) {
-    // console.log('Picture card already loaded');
-    return;
-  }
-  const config = {
-    type: 'picture',
-    image: 'https://demo.home-assistant.io/stub_config/t-shirt-promo.png',
-  };
-  if (helpers) await helpers.createCardElement(config);
-  else {
-    await helperPromise;
-    await helpers.createCardElement(config).catch((error: any) => {
-      console.error('Error loading picture card:', error);
-    });
-  }
-};
-
-// get the ha-picture-upload editor to load the upload form component
-export const loadPictureCardHelper = async (hass: HomeAssistant): Promise<void> => {
-  await loadPictureCard();
-  const picConfig = {
-    type: 'picture',
-    image: 'https://demo.home-assistant.io/stub_config/t-shirt-promo.png',
-  };
-  const pictureEditor = await (customElements.get(HUI_PICTURE_CARD) as any).getConfigElement();
-  pictureEditor.setConfig(picConfig);
-  pictureEditor.hass = hass;
-  const dummy = document.createElement('div');
-  dummy.style.display = 'none';
-  dummy.appendChild(pictureEditor);
-  document.body.appendChild(dummy);
-  // remove the dummy element after a delay to ensure the upload form is loaded.
-  window.setTimeout(() => {
-    if (dummy.parentNode) {
-      dummy.parentNode.removeChild(dummy);
-    }
-  }, 100);
-  return;
 };
 
 export async function createHuiElement(elementConfig: LovelaceElementConfig): Promise<LovelaceElement> {

--- a/src/utils/lovelace/create-card-element.ts
+++ b/src/utils/lovelace/create-card-element.ts
@@ -3,8 +3,6 @@ import type { LovelaceCardConfig } from '../../ha';
 import { HomeAssistant } from '../../ha';
 import { LovelaceElement, LovelaceElementConfig } from '../../ha/panels/lovelace/elements/types';
 
-let helpers = (window as any).cardHelpers;
-
 /**
  *
  * @param hass Home Assistant instance
@@ -19,6 +17,7 @@ export async function createCardElement(
     return;
   }
 
+  const helpers = await (window as any).loadCardHelpers();
   // Check if helpers were loaded and if createCardElement exists
   if (!helpers || !helpers.createCardElement) {
     console.error('Card helpers or createCardElement not available.');
@@ -48,6 +47,7 @@ export const loadVerticalStackCard = async (): Promise<void> => {
   }
 
   if (!customElements.get(VERTICAL_STACK_TAG)) {
+    const helpers = await (window as any).loadCardHelpers();
     await helpers.createCardElement({
       type: 'vertical-stack',
       cards: [],
@@ -56,6 +56,7 @@ export const loadVerticalStackCard = async (): Promise<void> => {
 };
 
 export async function createHuiElement(elementConfig: LovelaceElementConfig): Promise<LovelaceElement> {
+  const helpers = await (window as any).loadCardHelpers();
   const element = await helpers?.createHuiElement(elementConfig);
   if (element.tagName !== 'HUI-CONDITIONAL-ELEMENT') {
     element.classList.add('element');


### PR DESCRIPTION
Enhance the handling of hidden indicators by applying `display: none` to fully release space, allowing other indicators to utilize the area evenly. Update alignment component handling and type definitions in row indicators for better type safety. Remove unused picture card loading functions and simplify dialog helper logic to improve code maintainability.

Fixes #264