### PR TITLE
fix(map): scan feature.context for municipality in MapTiler reverse-geocode

### DIFF
--- a/src/utils/lovelace/create-map-card.ts
+++ b/src/utils/lovelace/create-map-card.ts
@@ -89,7 +89,7 @@ export async function getAddressFromMapTiler(lat: number, lon: number, apiKey: s
     if (data && data.features && data.features.length > 0) {
       let address: Partial<Address> = {};
 
-      // Iterate through each feature
+      // Iterate through each feature (top-level)
       data.features.forEach((feature: any) => {
         const placeType = feature.place_type[0]; // e.g. "address", "locality", "municipality"
         if (filterParams[placeType]) {
@@ -103,6 +103,18 @@ export async function getAddressFromMapTiler(lat: number, lon: number, apiKey: s
           // Assign filtered data to the corresponding property in the address object
           address[key] = `${text}`;
           // console.log(`Found ${key}:`, address[key], 'from', placeType);
+        }
+
+        // Also scan feature.context for missing fields. MapTiler returns
+        // `municipality` (city) only inside the address feature's context array,
+        // never as a top-level feature, so the loop above misses it.
+        if (Array.isArray(feature.context)) {
+          feature.context.forEach((ctx: any) => {
+            const ctxType = (ctx.id || '').split('.')[0]; // e.g. "municipality" from "municipality.32280"
+            if (filterParams[ctxType] && !address[filterParams[ctxType]]) {
+              address[filterParams[ctxType]] = `${ctx.text}`;
+            }
+          });
         }
       });
 


### PR DESCRIPTION
## Problem

When `maptiler_api_key` is configured on the mini-map, the address overlay shows empty (or just the marker icon) for many EU addresses.

Root cause: `getAddressFromMapTiler()` in `src/utils/lovelace/create-map-card.ts` iterates `data.features` and matches each top-level `place_type` against `filterParams = { address, locality, municipality }`. But the MapTiler reverse-geocoding API returns `municipality` only inside `feature.context[]`, **never** as a top-level feature.

Result:

- `address.streetName` ✓ (from top-level `address` feature)
- `address.sublocality` ✓ (from top-level `locality` feature)
- `address.city` ✗ — never populated

The validator `if (address.streetName && address.city)` then fails, the function returns `null`, `_address` stays null, and `_renderAddress()` returns an empty result because `address.streetName` is undefined.

## Reproduction

Lat/lon `52.3791, 4.9003` (Amsterdam Centraal area):

```bash
curl -s "https://api.maptiler.com/geocoding/4.9003,52.3791.json?key=YOUR_KEY" \
  | jq '.features[] | .place_type[0]'
```

Top-level `place_type` values returned: `address`, `postal_code`, `place`, `locality`, `major_landform`, `subregion`, `region`, `country`, `continental_marine` — **no `municipality`**.

The municipality (Amsterdam as a city, distinct from the provincial-level entity exposed via `subregion`) is only present inside `features[0].context[]`:

```json
{
  "id": "municipality.23043",
  "text": "Amsterdam",
  "kind": "admin_area"
}
```

## Fix

In addition to the existing top-level loop, scan each feature's `context[]` for any filterable type that wasn't already populated. The lookup is idempotent — won't overwrite values found at the top level.

```ts
if (Array.isArray(feature.context)) {
  feature.context.forEach((ctx: any) => {
    const ctxType = (ctx.id || '').split('.')[0];
    if (filterParams[ctxType] && !address[filterParams[ctxType]]) {
      address[filterParams[ctxType]] = `${ctx.text}`;
    }
  });
}
```

## After

For the same Amsterdam coords, the address feature has `text: "Stationsplein"`, `address: "41k"`, and `municipality.23043` in its context. After the fix:

- `address.streetName = "Stationsplein"` ✓
- `address.streetNumber = "41k"` ✓
- `address.sublocality = "Amsterdam"` ✓
- `address.city = "Amsterdam"` ✓ ← from `municipality.23043` in `features[0].context`

Validator passes, mini-map renders the street + city as expected.

## Notes

- Edge-case-safe: guarded with `Array.isArray(feature.context)`, only fills missing fields, gracefully handles missing `ctx.id`.
- No new dependencies, no schema changes, no breaking config changes.
- No changes to OSM or Google paths.
