### PR TITLE
feat: Add row_visibility property for dynamic visibility control

### DIFF
--- a/src/components/vsc-indicator-row.ts
+++ b/src/components/vsc-indicator-row.ts
@@ -1,13 +1,14 @@
+import { UnsubscribeFunc } from 'home-assistant-js-websocket';
 import { html, css, CSSResultGroup, TemplateResult, PropertyValues, nothing } from 'lit';
 import { customElement, property, query, queryAll, state } from 'lit/decorators.js';
-import { repeat } from 'lit/directives/repeat.js';
 
 import '../components/shared/indicator-row/vsc-indicator-item';
+import { repeat } from 'lit/directives/repeat.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
 import { VscIndicatorItem } from '../components/shared/indicator-row/vsc-indicator-item';
 import { COMPONENT } from '../constants/const';
-import { fireEvent } from '../ha';
+import { fireEvent, hasTemplate, RenderTemplateResult, subscribeRenderTemplate } from '../ha';
 import { getGroupEntities, GroupEntity, isGroupEntity } from '../ha/data/group';
 import {
   IndicatorRowGroupConfig,
@@ -35,14 +36,21 @@ declare global {
   }
 }
 
+const TEMPLATE_KEYS = ['row_visibility'] as const;
+type TemplateKey = (typeof TEMPLATE_KEYS)[number];
 @customElement(COMPONENT.INDICATOR_ROW)
 export class VscIndicatorRow extends BaseElement {
+  constructor() {
+    super();
+  }
   @property({ attribute: false }) private rowConfig!: IndicatorRowConfig;
   @property({ type: Boolean, reflect: true }) private active = false;
   @property({ type: Number, attribute: 'row-index', reflect: true }) public rowIndex?: number;
   @property({ type: Number, attribute: 'item-index', reflect: true }) public itemIndex?: number | null = null;
   @property({ type: Boolean, reflect: true, attribute: 'editor-dimmed' }) public dimmedInEditor = false;
-
+  @property({ type: Boolean, reflect: true }) private isVisible = true;
+  @state() protected _singleTemplateResults: Partial<Record<TemplateKey, RenderTemplateResult | undefined>> = {};
+  @state() protected _unsubSingleRenderTemplates: Map<TemplateKey, Promise<UnsubscribeFunc>> = new Map();
   @state() _selectedGroupId: number | null = null;
   @state() private _rowItems?: IndicatorRowItem[];
 
@@ -55,17 +63,86 @@ export class VscIndicatorRow extends BaseElement {
 
   @state() private _resizeObs?: ResizeObserver;
 
-  connectedCallback(): void {
+  connectedCallback() {
     super.connectedCallback();
+    this._tryConnect();
     if (this.rowConfig.no_wrap && this._rowEl) {
       // console.debug('Binding row events with connectedCallback');
       this._bindRowEvents();
       this._updateArrows();
     }
   }
-  disconnectedCallback(): void {
+  disconnectedCallback() {
+    this._tryDisconnect();
     this._unbindRowEvents();
     super.disconnectedCallback();
+  }
+
+  private async _tryConnect(): Promise<void> {
+    TEMPLATE_KEYS.forEach((key) => {
+      this._subscribeRenderTemplate(key);
+    });
+  }
+
+  private async _subscribeRenderTemplate(key: TemplateKey): Promise<void> {
+    if (this._unsubSingleRenderTemplates.get(key) !== undefined || !this._hass || !hasTemplate(this.rowConfig[key])) {
+      return;
+    }
+    try {
+      const sub = subscribeRenderTemplate(
+        this.hass.connection,
+        (result) => {
+          this._singleTemplateResults = { ...this._singleTemplateResults, [key]: result };
+        },
+        {
+          template: this.rowConfig[key] ?? '',
+          variables: {
+            user: this.hass.user!.name,
+          },
+          strict: true,
+        }
+      );
+      this._unsubSingleRenderTemplates.set(key, sub);
+      await sub;
+    } catch (e) {
+      console.warn('Error while rendering template', e);
+      const result = {
+        result: this.rowConfig[key] ?? '',
+        listeners: {
+          all: false,
+          domains: [],
+          entities: [],
+          time: false,
+        },
+      };
+      this._singleTemplateResults = { ...this._singleTemplateResults, [key]: result };
+      this._unsubSingleRenderTemplates.delete(key);
+    }
+  }
+
+  private async _tryDisconnect(): Promise<void> {
+    TEMPLATE_KEYS.forEach((key) => {
+      this._tryDisconnectKey(key);
+    });
+  }
+
+  private async _tryDisconnectKey(key: TemplateKey): Promise<void> {
+    const unsubRenderTemplate = this._unsubSingleRenderTemplates.get(key);
+    if (!unsubRenderTemplate) {
+      return;
+    }
+
+    try {
+      const unsub = await unsubRenderTemplate;
+      unsub();
+      this._unsubSingleRenderTemplates.delete(key);
+    } catch (err: any) {
+      if (err.code === 'not_found' || err.code === 'template_error') {
+        // If we get here, the connection was probably already closed. Ignore.
+      } else {
+        throw err;
+      }
+    }
   }
 
   protected async firstUpdated(changedProperties: PropertyValues): Promise<void> {
@@ -88,6 +165,9 @@ export class VscIndicatorRow extends BaseElement {
       if (!this.isBaseInEditor) return;
       // Notify editor if group active state changes
       fireEvent(this, 'group-active', this.active);
+    }
+    if (_changedProperties.has('_hass') && this._hass) {
+      this._tryConnect();
     }
   }
 
@@ -158,7 +238,24 @@ export class VscIndicatorRow extends BaseElement {
     if (this._showRightArrow !== showRight) this._showRightArrow = showRight;
   }
 
-  protected render(): TemplateResult {
+  private _getValue(key: TemplateKey): string | undefined {
+    const templateResult = this._singleTemplateResults[key];
+    if (templateResult) {
+      return templateResult.result;
+    }
+    return undefined;
+  }
+  get visibility(): boolean {
+    const val = this._getValue('row_visibility');
+    if (val === undefined) return true;
+    if (typeof val === 'boolean') return val;
+    return val === 'true';
+  }
+
+  protected render(): TemplateResult | typeof nothing {
+    if (this.visibility === false) {
+      return nothing;
+    }
     const rowItems = this._rowItems || [];
     const active = this.active;
     const noWrap = this.rowConfig.no_wrap;

--- a/src/components/vsc-indicator-row.ts
+++ b/src/components/vsc-indicator-row.ts
@@ -246,6 +246,9 @@ export class VscIndicatorRow extends BaseElement {
     return undefined;
   }
   get visibility(): boolean {
+    if (this.isBaseInEditor) {
+      return true;
+    }
     const val = this._getValue('row_visibility');
     if (val === undefined) return true;
     if (typeof val === 'boolean') return val;

--- a/src/editor/components/indicators/panel-row-item.ts
+++ b/src/editor/components/indicators/panel-row-item.ts
@@ -84,6 +84,7 @@ export class PanelIndicatorItem extends BaseEditor {
       global_icon_size: ROW_DATA?.global_icon_size,
       global_column_reverse: ROW_DATA?.global_column_reverse,
       global_row_reverse: ROW_DATA?.global_row_reverse,
+      row_visibility: ROW_DATA?.row_visibility,
     };
 
     const noWrapEl = this._createVscForm({ no_wrap: ROW_DATA?.no_wrap }, ROW_NO_WRAP_SCHEMA, 'icon_size_no_wrap');

--- a/src/editor/form/indicator-row-schema.ts
+++ b/src/editor/form/indicator-row-schema.ts
@@ -62,21 +62,6 @@ export const ICON_SIZE_SCHEMA = [
     selector: { number: { min: 14, step: 1, mode: 'box', unit_of_measurement: 'px' } },
   },
 ] as const;
-// export const ICON_SIZE_SCHEMA = (helper?: string) => {
-//   if (!helper) {
-//     helper = 'Size for all icons in the row.';
-//   }
-//   return [
-//     {
-//       name: 'icon_size',
-//       label: 'Icon Size (px)',
-//       helper: helper,
-//       required: false,
-//       default: 21,
-//       selector: { number: { min: 14, step: 1, mode: 'box', unit_of_measurement: 'px' } },
-//     },
-//   ] as const;
-// };
 
 export interface BooleanItemSchema {
   type: 'boolean';
@@ -208,6 +193,61 @@ export const computeBooleanList = (keys?: BooleanKey[]) => {
   return list;
 };
 
+const TEMPLATES = [
+  {
+    name: 'visibility',
+    label: 'Visibility Template',
+    helper: 'Hide or show the indicator based on a template. The template should return true or false.',
+  },
+  {
+    name: 'state_template',
+    label: 'State Template',
+    helper: 'Customize the state based on a template. The template should return a valid state name.',
+  },
+  {
+    name: 'icon_template',
+    label: 'Icon Template',
+    helper: 'Template to override the icon. The template should return a valid icon name.',
+  },
+  {
+    name: 'color_template',
+    label: 'Color Template',
+    helper: 'Template to override the color. The template should return a valid CSS color (name, hex, rgb, hsl, etc.).',
+  },
+  {
+    name: 'row_visibility',
+    label: 'Row Visibility Template',
+    helper: 'Hide or show the entire row based on a template. False result hides whole row.',
+  },
+];
+
+const TemplateKeys = TEMPLATES.map((t) => t.name);
+type TemplateKey = (typeof TemplateKeys)[number];
+
+export const computeTemplateSchema = (type?: TemplateKey[], exclude?: TemplateKey[]) => {
+  if (!type) {
+    type = TemplateKeys;
+  }
+  if (exclude) {
+    type = type.filter((key) => !exclude.includes(key));
+  }
+  const list: TemplateItem[] = [];
+  type.forEach((key) => {
+    const t = TEMPLATES.find((tt) => tt.name === key);
+    if (t) {
+      list.push({
+        name: t.name,
+        label: t.label,
+        helper: t.helper,
+        selector: {
+          template: {},
+        },
+      });
+    }
+  });
+  return list;
+};
+
 export const ROW_ICON_SIZE_NO_WRAP_SCHEMA = [
   {
     title: 'Global Appearance (optional)',
@@ -231,6 +271,12 @@ export const ROW_ICON_SIZE_NO_WRAP_SCHEMA = [
           ...computeBooleanSchema(GLOBAL_BOOLEAN_KEYS as BooleanKey[]),
         ],
       },
+      {
+        type: 'expandable',
+        flatten: true,
+        title: 'Extra Templates (Advanced)',
+        schema: [...computeTemplateSchema(['row_visibility'])],
+      },
     ],
   },
 ] as const;
@@ -244,53 +290,6 @@ export const ROW_INTERACTON_BASE_SCHEMA = [
     schema: [...computeOptionalActionSchemaFull()],
   },
 ] as const;
-
-const TEMPLATES = [
-  {
-    name: 'visibility',
-    label: 'Visibility Template',
-    helper: 'Hide or show the indicator based on a template. The template should return true or false.',
-  },
-  {
-    name: 'state_template',
-    label: 'State Template',
-    helper: 'Customize the state based on a template. The template should return a valid state name.',
-  },
-  {
-    name: 'icon_template',
-    label: 'Icon Template',
-    helper: 'Template to override the icon. The template should return a valid icon name.',
-  },
-  {
-    name: 'color_template',
-    label: 'Color Template',
-    helper: 'Template to override the color. The template should return a valid CSS color (name, hex, rgb, hsl, etc.).',
-  },
-];
-
-const TemplateKeys = TEMPLATES.map((t) => t.name);
-type TemplateKey = (typeof TemplateKeys)[number];
-
-export const computeTemplateSchema = (type?: TemplateKey[]) => {
-  if (!type) {
-    type = TemplateKeys;
-  }
-  const list: TemplateItem[] = [];
-  type.forEach((key) => {
-    const t = TEMPLATES.find((tt) => tt.name === key);
-    if (t) {
-      list.push({
-        name: t.name,
-        label: t.label,
-        helper: t.helper,
-        selector: {
-          template: {},
-        },
-      });
-    }
-  });
-  return list;
-};
 
 // SINGLE ENTITY TYPE SCHEMA
 export const ROW_ITEM_CONTENT_SCHEMA = () =>
@@ -498,7 +497,7 @@ export const OPTIONAL_TEMPLATE_SCHEMA = [
         type: 'optional_actions',
         flatten: true,
         context: { isTemplate: true },
-        schema: [...computeTemplateSchema()],
+        schema: [...computeTemplateSchema(undefined, ['row_visibility'])],
       },
     ],
   },

--- a/src/types/config/card/row-indicators.ts
+++ b/src/types/config/card/row-indicators.ts
@@ -91,6 +91,7 @@ export interface IndicatorRowConfig extends GlobalAppearanceConfig {
   row_items: IndicatorRowItem[]; // Array of indicator items in the row
   alignment?: Alignment;
   no_wrap?: boolean;
+  row_visibility?: string;
 }
 
 export interface LovelaceIndicatorRowItem extends HTMLElement {


### PR DESCRIPTION
Introduce a new `row_visibility` property in the `IndicatorRowConfig` to enable dynamic control of row visibility.

Closes #273