### PR TITLE
feat(mini-map): add option to disable inline map interaction while scrolling

### DIFF
--- a/src/components/vsc-mini-map.ts
+++ b/src/components/vsc-mini-map.ts
@@ -82,6 +82,10 @@ export class MiniMapBox extends BaseElement {
     return this.mapConfig?.user_location || false;
   }
 
+  private get interactionDisabled(): boolean {
+    return this.mapConfig?.disable_interaction || false;
+  }
+
   private get _deviceState(): string {
     const deviceTracker = this.mapConfig.device_tracker!;
     const stateObj = this._hass.states[deviceTracker];
@@ -213,10 +217,16 @@ export class MiniMapBox extends BaseElement {
     console.log('Initializing map...');
     const { lat, lon } = this.mapData!;
     const defaultZoom = this.zoom;
+    const interactionDisabled = this.interactionDisabled;
     const mapOptions = {
-      dragging: true,
+      dragging: !interactionDisabled,
       zoomControl: false,
-      scrollWheelZoom: true,
+      scrollWheelZoom: !interactionDisabled,
+      doubleClickZoom: !interactionDisabled,
+      touchZoom: !interactionDisabled,
+      boxZoom: !interactionDisabled,
+      keyboard: !interactionDisabled,
+      tap: !interactionDisabled,
       zoom: defaultZoom,
     };
 
@@ -227,6 +237,18 @@ export class MiniMapBox extends BaseElement {
     this.latLon = this._getTargetLatLng(this.map);
     // Add tile layer to map
     this._createTileLayer(this.map);
+
+    if (interactionDisabled) {
+      // Preview mode: the map itself stays non-interactive so it doesn't
+      // capture drag/scroll gestures meant for the dashboard. A tap still
+      // opens the popup (mirrors the marker's own click handler) when enabled.
+      mapContainer.classList.add('interaction-disabled');
+      if (this.mapPopup) {
+        this.map.on('click', () => {
+          this._toggleDialog();
+        });
+      }
+    }
 
     this.map.on('moveend zoomend', () => {
       // check visibility of marker icon on view
@@ -520,6 +542,13 @@ export class MiniMapBox extends BaseElement {
           background-color: transparent !important;
           mask-image: var(--vic-map-mask-image);
           mask-composite: intersect;
+        }
+
+        #map.interaction-disabled {
+          /* Let vertical swipes fall through to the dashboard for scrolling
+             instead of being captured by Leaflet's drag handling. */
+          touch-action: pan-y;
+          cursor: pointer;
         }
 
         .map-tiles {

--- a/src/editor/form/map-schema.ts
+++ b/src/editor/form/map-schema.ts
@@ -16,7 +16,19 @@ export const BASE_MAP_SCHEMA = [
   },
 ] as const;
 
-const LAYOUT_BOOL = ['enable_popup', 'us_format', 'hide_map_address', 'use_zone_name', 'user_location'] as const;
+const LAYOUT_BOOL = [
+  'enable_popup',
+  'us_format',
+  'hide_map_address',
+  'use_zone_name',
+  'user_location',
+  'disable_interaction',
+] as const;
+
+const LAYOUT_BOOL_HELPER: Partial<Record<(typeof LAYOUT_BOOL)[number], string>> = {
+  disable_interaction:
+    'Prevents dragging/panning and scroll-zoom on the inline map so it no longer intercepts dashboard scroll gestures. Tap the map to open the popup instead.',
+};
 
 export const MINI_MAP_LAYOUT_SCHEMA = [
   {
@@ -31,6 +43,7 @@ export const MINI_MAP_LAYOUT_SCHEMA = [
         schema: [
           ...LAYOUT_BOOL.map((name) => ({
             name,
+            helper: LAYOUT_BOOL_HELPER[name],
             selector: { boolean: {} },
           })),
         ] as const,

--- a/src/types/config/card/mini-map.ts
+++ b/src/types/config/card/mini-map.ts
@@ -44,6 +44,7 @@ export interface MinimapLayoutConfig {
   map_zoom?: number;
   use_zone_name?: boolean;
   user_location?: boolean;
+  disable_interaction?: boolean;
 }
 
 export interface MapPopupSharedConfig {


### PR DESCRIPTION
A scroll/swipe gesture that starts over the mini map was captured by Leaflet's drag handling and panned the map instead of scrolling the dashboard. Add a `disable_interaction` config option (exposed as a toggle in the visual editor) that turns off dragging, scroll/touch zoom, double-click zoom, box zoom and keyboard panning on the inline map.

A plain tap still opens the popup dialog via Leaflet's native click event, so full interaction stays one tap away when `enable_popup` is on; only continuous drag/scroll gestures are ignored.

Ref #286

Did test it fast locally in docker:
<img width="2125" height="1618" alt="image" src="https://github.com/user-attachments/assets/52a5a8df-074b-4e5b-bf20-6eba524b33ec" />

Feels maybe bloated with the info text there as well, but should maybe otherwise be added to documentation somewhere to describe the switch.

Gif showing interaction toggled off/on:
<img width="2577" height="1568" alt="gif_test" src="https://github.com/user-attachments/assets/e79a7721-a70f-489a-add2-669bf496abc0" />
